### PR TITLE
Fix "Large model stuck in PYNQ"

### DIFF
--- a/drivers/tcu_pynq/driver.py
+++ b/drivers/tcu_pynq/driver.py
@@ -227,7 +227,8 @@ class Driver:
         def timestamp(event):
             nonlocal prev
             now = time.time()
-            print("{}\t{:.3}s\t{:.3}s".format(event, now - prev, now - start))
+            if self.debug:
+                print("{}\t{:.3}s\t{:.3}s".format(event, now - prev, now - start))
             prev = now
 
         if self.model is None:

--- a/drivers/tcu_pynq/stream.py
+++ b/drivers/tcu_pynq/stream.py
@@ -29,9 +29,9 @@ class Channel:
         An instance of Allocator
     """
 
-    def __init__(self, dma_channel, data_type, max_buffer_size, allocator):
+    def __init__(self, dma_channel, axi_data_width, max_buffer_size, allocator):
         self.dma_channel = dma_channel
-        self.data_type = data_type
+        self.axi_data_width = axi_data_width
         self.max_buffer_size = max_buffer_size
         self.allocator = allocator
 
@@ -59,14 +59,14 @@ class DoubleBufferedAdapter:
         self.wait = self.channel.wait
         self.copy = self.channel.copy
         self.free = self.channel.free
-        self.max_buffer_size = self.channel.max_buffer_size
+        self.axi_data_width = self.channel.axi_data_width
+        self.max_buffer_size = self.channel.max_buffer_size        
 
         # state
         self.data = None  # data to read/write
         self.total_length = 0  # total number of transfers required
-        self.remainder_length = (
-            0  # size of first transfer = total_length % max_buffer_size
-        )
+        self.buffer_size = 0 # size of each buffer in the pair
+        self.remainder_buffer_size = 0 # size of first remainder buffer if total_length % buffer_size == 0
         self.buffer = list()  # buffers to read and write
         self.current = 2  # index of current buffer
         self.alternate = 0  # index of alternate buffer
@@ -76,19 +76,23 @@ class DoubleBufferedAdapter:
 
     def read(self, data):
         """Reads into buffer data"""
-        self._loop(data, False)
+        self._loop(data, False, 1)
 
-    def write(self, data):
+    def write(self, data, align=1):
         """Writes from buffer data"""
-        self._loop(data, True)
+        self._loop(data, True, align)
 
-    def _init_buffers(self, total_length):
+    def _init_buffers(self, total_length, align):
         self.total_length = total_length
-        self.remainder_length = self.total_length % self.max_buffer_size
+
+        align_data_width_lcm = lcm(align, self.axi_data_width // 8)
+        self.buffer_size = self.max_buffer_size - (self.max_buffer_size % align_data_width_lcm)
+
+        self.remainder_buffer_size = self.total_length % self.buffer_size
         self.buffer = [
-            self.make_buffer(self.max_buffer_size),
-            self.make_buffer(self.max_buffer_size),
-            self.make_buffer(self.remainder_length),
+            self.make_buffer(self.buffer_size),
+            self.make_buffer(self.buffer_size),
+            self.make_buffer(self.remainder_buffer_size),
         ]
 
     def _del_buffers(self):
@@ -96,18 +100,18 @@ class DoubleBufferedAdapter:
             self.free(buf)
         self.buffer = list()
 
-    def _loop(self, data, write):
+    def _loop(self, data, write, align):
         """
         write : bool
             False = read, True = write
         """
         self.data = data
-        self._init_buffers(len(self.data))
-        self.current = 2 if self.remainder_length > 0 else 0
-        self.alternate = 1
+        self._init_buffers(len(self.data), align)
+        self.current = 2 if self.remainder_buffer_size > 0 else 0
+        self.next = 1
+        self.prev = -1
         self.transferred = 0
         self.index = 0
-        self.first = True
 
         if write:
             self.copy(
@@ -118,42 +122,43 @@ class DoubleBufferedAdapter:
                 len(self.buffer[self.current]),
             )
             self.index += len(self.buffer[self.current])
+
         while self.transferred < self.total_length:
             self.transfer(self.buffer[self.current])
             self.transferred += len(self.buffer[self.current])
             if write:
                 # only necessary if there is another transferred needed
-                if self.index + len(self.buffer[self.alternate]) <= self.total_length:
+                if self.index + len(self.buffer[self.next]) <= self.total_length:
                     self.copy(
                         self.data,
                         self.index,
-                        self.buffer[self.alternate],
+                        self.buffer[self.next],
                         0,
-                        len(self.buffer[self.alternate]),
+                        len(self.buffer[self.next]),
                     )
-                    self.index += len(self.buffer[self.alternate])
-            else:
+                    self.index += len(self.buffer[self.next])
+            else:                
                 # only necessary if we've already done a transfer
-                if not self.first:
+                if self.prev >= 0:
                     self.copy(
-                        self.buffer[self.alternate],
+                        self.buffer[self.prev],
                         0,
                         self.data,
                         self.index,
-                        len(self.buffer[self.alternate]),
+                        len(self.buffer[self.prev]),
                     )
-                    self.index += len(self.buffer[self.alternate])
-            self.alternate = self.current
-            self.current = (self.current + 1) % 2
-            self.first = False
+                    self.index += len(self.buffer[self.prev])
+            self.prev = self.current
+            self.current = self.next
+            self.next = (self.next + 1) % 2
             self.wait()
         if not write:
             self.copy(
-                self.buffer[self.alternate],
+                self.buffer[self.prev],
                 0,
                 self.data,
                 self.index,
-                len(self.buffer[self.alternate]),
+                len(self.buffer[self.prev]),
             )
         self._del_buffers()
 
@@ -163,19 +168,21 @@ class Stream:
     Stream provides a read and write interface to AXI DMA transfers
     """
 
-    def __init__(self, dma, dma_buffer_size, axi_data_width, allocator):
+    def __init__(self, dma, max_buffer_size, axi_data_width, allocator):
         """
         Parameters
         --------------
         dma : DMA
             An instance of a pynq DMA
+        max_buffer_size : int
+            The maximum allowable size for a buffer
         axi_data_width : int
             Width in bits of the AXI data bus
         allocator : Allocator
             An instance of Allocator
         """
         self.dma = dma
-        self.dma_buffer_size = dma_buffer_size
+        self.max_buffer_size = max_buffer_size
         self.axi_data_width = axi_data_width
         if self.axi_data_width % 8 != 0:
             raise Exception(
@@ -187,15 +194,15 @@ class Stream:
         self.axi_data_type = axi_data_type(axi_data_width)
         self.send_channel = Channel(
             self.dma.sendchannel,
-            self.axi_data_type,
-            self.dma_buffer_size,
+            self.axi_data_width,
+            self.max_buffer_size,
             self.allocator,
         )
         self.send_adapter = DoubleBufferedAdapter(self.send_channel)
         self.receive_channel = Channel(
             self.dma.recvchannel,
-            self.axi_data_type,
-            self.dma_buffer_size,
+            self.axi_data_width,
+            self.max_buffer_size,
             self.allocator,
         )
         self.receive_adapter = DoubleBufferedAdapter(self.receive_channel)
@@ -218,9 +225,9 @@ class Stream:
         align : int (optional) >= 1
             word size in bytes to align the stream on
         """
-        align_lcm = lcm(align, self.axi_data_width // 8)
-        remainder = align_lcm - (len(data) % align_lcm)
+        align_data_width_lcm = lcm(align, self.axi_data_width // 8)
+        remainder = align_data_width_lcm - (len(data) % align_data_width_lcm)
         if remainder != 0:
             data = data + bytes([0 for i in range(remainder)])
         write_data = np.frombuffer(data, dtype=np.uint8).view(self.axi_data_type)
-        self.send_adapter.write(write_data)
+        self.send_adapter.write(write_data, align)

--- a/drivers/tcu_pynq/stream_test.py
+++ b/drivers/tcu_pynq/stream_test.py
@@ -8,6 +8,7 @@ import unittest
 
 class MockSendChannel:
     def __init__(self):
+        self.axi_data_width = 8
         self.max_buffer_size = 8
         self.dtype = np.uint8
         self.transfer_requested = False
@@ -37,6 +38,7 @@ class MockSendChannel:
 
 class MockRecvChannel:
     def __init__(self):
+        self.axi_data_width = 8
         self.max_buffer_size = 8
         self.dtype = np.uint8
         self.transfer_requested = False
@@ -76,8 +78,18 @@ class DoubleBufferedAdapterWriteTest(unittest.TestCase):
         self.adapter.write(data)
         np.testing.assert_array_equal(self.channel.written, data)
 
-    def test_remainder_write(self):
+    def test_remainder_write_buffer_plus1(self):
         data = np.arange(self.channel.max_buffer_size + 1, dtype=self.channel.dtype)
+        self.adapter.write(data)
+        np.testing.assert_array_equal(self.channel.written, data)
+
+    def test_remainder_write_buffer_x2_plus1(self):
+        data = np.arange(self.channel.max_buffer_size * 2 + 1, dtype=self.channel.dtype)
+        self.adapter.write(data)
+        np.testing.assert_array_equal(self.channel.written, data)
+
+    def test_remainder_write_buffer_x5_plus1(self):
+        data = np.arange(self.channel.max_buffer_size * 5 + 1, dtype=self.channel.dtype)
         self.adapter.write(data)
         np.testing.assert_array_equal(self.channel.written, data)
 
@@ -99,8 +111,22 @@ class DoubleBufferedAdapterReadTest(unittest.TestCase):
         self.adapter.read(data)
         np.testing.assert_array_equal(self.channel.read, data)
 
-    def test_remainder_read(self):
+    def test_remainder_read_plus1(self):
         size = self.channel.max_buffer_size + 1
+        self.channel.read = np.arange(size, dtype=self.channel.dtype)
+        data = np.zeros(size, dtype=self.channel.dtype)
+        self.adapter.read(data)
+        np.testing.assert_array_equal(self.channel.read, data)
+
+    def test_remainder_read_buffer_x2_plus1(self):
+        size = self.channel.max_buffer_size * 2 + 1
+        self.channel.read = np.arange(size, dtype=self.channel.dtype)
+        data = np.zeros(size, dtype=self.channel.dtype)
+        self.adapter.read(data)
+        np.testing.assert_array_equal(self.channel.read, data)
+
+    def test_remainder_read_buffer_x5_plus1(self):
+        size = self.channel.max_buffer_size * 5 + 1
         self.channel.read = np.arange(size, dtype=self.channel.dtype)
         data = np.zeros(size, dtype=self.channel.dtype)
         self.adapter.read(data)


### PR DESCRIPTION
- Fix next/current/previous buffer state management in `DoubleBufferedAdapter._loop`;
- Ensure each DMA transfer is correctly aligned;
- Print timing only when debug flag is set.