### PR TITLE
Improve routing to boost clock rate

### DIFF
--- a/build.sc
+++ b/build.sc
@@ -92,6 +92,8 @@ object sim extends ScalaModule { m =>
   object test extends Tests with ScalaTest {
     def moduleDeps = super.moduleDeps ++ Seq(rtl.test, tools.test)
 
+    def forkArgs = Seq("-Xmx48g", "-Xmx48g")
+
     override def ivyDeps =
       m.ivyDeps() ++ Agg(ivy"org.scalatest::scalatest:3.0.4")
   }

--- a/common/src/tensil/ArchitectureDataType.scala
+++ b/common/src/tensil/ArchitectureDataType.scala
@@ -35,7 +35,7 @@ class ArchitectureDataTypeWithBase[T](
   def writeFloatConst(f: Float, stream: DataOutputStream): Unit =
     writeConst(base.fromFloat(f), stream)
   def readFloatConst(stream: DataInputStream): Float =
-    base.numeric.toFloat(readConst(stream))
+    base.numericWithMAC.toFloat(readConst(stream))
 
   def writeConst(v: T, stream: DataOutputStream): Unit =
     stream.write(base.toBytes(v))

--- a/common/src/tensil/DataTypeBase.scala
+++ b/common/src/tensil/DataTypeBase.scala
@@ -12,7 +12,7 @@ abstract class DataTypeBase[T] {
   def fromFloat(f: Float): T
   def fromDouble(d: Double): T
 
-  implicit def numeric: Numeric[T]
+  implicit def numericWithMAC: NumericWithMAC[T]
 
   def resetOverUnderflowStats(): Unit
   def reportOverUnderflowStats(): Unit

--- a/common/src/tensil/Fixed16bp8.scala
+++ b/common/src/tensil/Fixed16bp8.scala
@@ -16,5 +16,5 @@ object Fixed16bp8
       toLongBits = (fixed: Fixed16bp8) => fixed.bits.toLong
     ) {
 
-  implicit val numeric = mkNumeric
+  implicit val numericWithMAC = mkNumericWithMAC
 }

--- a/common/src/tensil/Fixed18bp10.scala
+++ b/common/src/tensil/Fixed18bp10.scala
@@ -16,5 +16,5 @@ object Fixed18bp10
       toLongBits = (fixed: Fixed18bp10) => fixed.bits.toLong
     ) {
 
-  implicit val numeric = mkNumeric
+  implicit val numericWithMAC = mkNumericWithMAC
 }

--- a/common/src/tensil/Fixed32bp16.scala
+++ b/common/src/tensil/Fixed32bp16.scala
@@ -12,7 +12,7 @@ object Fixed32bp16
       toLongBits = (fixed: Fixed32bp16) => fixed.bits.toLong
     ) {
 
-  implicit val numeric = mkNumeric
+  implicit val numericWithMAC = mkNumericWithMAC
 }
 
 class Fixed32bp16(

--- a/common/src/tensil/Fixed8bp4.scala
+++ b/common/src/tensil/Fixed8bp4.scala
@@ -16,5 +16,5 @@ object Fixed8bp4
       toLongBits = (fixed: Fixed8bp4) => fixed.bits.toLong
     ) {
 
-  implicit val numeric = mkNumeric
+  implicit val numericWithMAC = mkNumericWithMAC
 }

--- a/common/src/tensil/FixedBase.scala
+++ b/common/src/tensil/FixedBase.scala
@@ -63,15 +63,18 @@ abstract class FixedBase[TFixed](
   def mkNumericWithMAC =
     new NumericWithMAC[TFixed] {
       override def plus(x: TFixed, y: TFixed): TFixed =
-        mac(y, fromInt(1), x)
+        mkFixed(doMAC(toLongBits(x), 1L << basePoint, toLongBits(y)))
       override def minus(x: TFixed, y: TFixed): TFixed =
-        mac(y, fromInt(-1), x)
+        mkFixed(doMAC(toLongBits(x), 1L << basePoint, -toLongBits(y)))
 
       override def times(x: TFixed, y: TFixed): TFixed =
-        mac(x, y, fromInt(0))
+        mkFixed(doMAC(toLongBits(x), toLongBits(y), 0L))
 
-      override def mac(x: TFixed, y: TFixed, z: TFixed): TFixed = {
-        val mac = toLongBits(x) * toLongBits(y) + (toLongBits(z) << basePoint)
+      override def mac(x: TFixed, y: TFixed, z: TFixed): TFixed =
+        mkFixed(doMAC(toLongBits(x), toLongBits(y), toLongBits(z)))
+
+      private def doMAC(x: Long, y: Long, z: Long): Long = {
+        val mac = (x * y) + (z << basePoint)
 
         /*
          * TDOD: Multiple rounding policies can be employed. Currently
@@ -105,7 +108,7 @@ abstract class FixedBase[TFixed](
         else 0
          */
 
-        mkFixed((mac >> basePoint) + adj)
+        (mac >> basePoint) + adj
       }
       override def negate(x: TFixed): TFixed =
         mkFixed(-toLongBits(x))

--- a/common/src/tensil/Float32.scala
+++ b/common/src/tensil/Float32.scala
@@ -11,6 +11,17 @@ import java.io.{
   DataInputStream
 }
 
+trait FloatAsIfIntegralWithMAC
+    extends FloatAsIfIntegral
+    with NumericWithMAC[Float] {
+  def mac(x: Float, y: Float, z: Float): Float =
+    x * y + z
+}
+
+object FloatAsIfIntegralWithMAC
+    extends FloatAsIfIntegralWithMAC
+    with Ordering.FloatOrdering {}
+
 object Float32 extends DataTypeBase[Float] {
   def sizeBytes: Int = 4
 
@@ -28,7 +39,7 @@ object Float32 extends DataTypeBase[Float] {
   def fromFloat(f: Float): Float   = f
   def fromDouble(d: Double): Float = d.toFloat
 
-  implicit val numeric = FloatAsIfIntegral
+  implicit val numericWithMAC = FloatAsIfIntegralWithMAC
 
   def resetOverUnderflowStats(): Unit = {}
   def reportOverUnderflowStats(): Unit = {}

--- a/common/src/tensil/NumericWithMAC.scala
+++ b/common/src/tensil/NumericWithMAC.scala
@@ -1,0 +1,5 @@
+package tensil
+
+trait NumericWithMAC[T] extends Numeric[T] {
+  def mac(x: T, y: T, z: T): T
+}

--- a/common/src/tensil/golden/Ops.scala
+++ b/common/src/tensil/golden/Ops.scala
@@ -1,0 +1,28 @@
+package tensil.golden
+
+import scala.reflect.ClassTag
+import tensil.NumericWithMAC
+
+object Ops {
+  def matMul[T : NumericWithMAC : ClassTag](
+      a: Array[Array[T]],
+      b: Array[Array[T]]
+  ): Array[Array[T]] = {
+    if (a.length == 0) return Array.empty[Array[T]]
+    if (a.head.length != b.length)
+      throw new Exception("Dimension size mismatch")
+    if (a.head.length == 0) return Array.empty[Array[T]]
+    if (b.head.length == 0) return Array.empty[Array[T]]
+    val result =
+      Array.fill(a.length, b.head.length)(implicitly[NumericWithMAC[T]].zero)
+    for (i <- a.indices) {
+      for (j <- a.head.indices) {
+        for (k <- b.head.indices) {
+          result(i)(k) =
+            implicitly[NumericWithMAC[T]].mac(a(i)(j), b(j)(k), result(i)(k))
+        }
+      }
+    }
+    result
+  }
+}

--- a/common/test/src/FixedSpec.scala
+++ b/common/test/src/FixedSpec.scala
@@ -13,28 +13,6 @@ class FixedSpec extends FlatSpec {
 
   implicit val numeric = FloatAsIfIntegralWithMAC
 
-  def goldenMatMatMul[T : NumericWithMAC : ClassTag](
-      a: Array[Array[T]],
-      b: Array[Array[T]]
-  ): Array[Array[T]] = {
-    if (a.length == 0) return Array.empty[Array[T]]
-    if (a.head.length != b.length)
-      throw new Exception("Dimension size mismatch")
-    if (a.head.length == 0) return Array.empty[Array[T]]
-    if (b.head.length == 0) return Array.empty[Array[T]]
-    val result =
-      Array.fill(a.length, b.head.length)(implicitly[NumericWithMAC[T]].zero)
-    for (i <- a.indices) {
-      for (j <- a.head.indices) {
-        for (k <- b.head.indices) {
-          result(i)(k) =
-            implicitly[NumericWithMAC[T]].mac(a(i)(j), b(j)(k), result(i)(k))
-        }
-      }
-    }
-    result
-  }
-
   it should "Fixed16bp8 matrix multiplication within error" in {
     val a =
       Array(
@@ -45,12 +23,12 @@ class FixedSpec extends FlatSpec {
     val b =
       Array(Array(.1f, .2f, .3f), Array(.4f, .5f, .6f), Array(.7f, .8f, .9f))
 
-    val yExpected = goldenMatMatMul(a, b).flatten
+    val yExpected = golden.Ops.matMul(a, b).flatten
 
     val af = a.map(_.map(Fixed16bp8.fromDouble(_)))
     val bf = b.map(_.map(Fixed16bp8.fromDouble(_)))
 
-    val yf = goldenMatMatMul(af, bf)
+    val yf = golden.Ops.matMul(af, bf)
 
     val y = yf.map(_.map(_.toDouble())).flatten
 
@@ -74,12 +52,12 @@ class FixedSpec extends FlatSpec {
     val b =
       Array(Array(.1f, .2f, .3f), Array(.4f, .5f, .6f), Array(.7f, .8f, .9f))
 
-    val yExpected = goldenMatMatMul(a, b).flatten
+    val yExpected = golden.Ops.matMul(a, b).flatten
 
     val af = a.map(_.map(Fixed18bp10.fromDouble(_)))
     val bf = b.map(_.map(Fixed18bp10.fromDouble(_)))
 
-    val yf = goldenMatMatMul(af, bf)
+    val yf = golden.Ops.matMul(af, bf)
 
     val y = yf.map(_.map(_.toDouble())).flatten
 
@@ -103,12 +81,12 @@ class FixedSpec extends FlatSpec {
     val b =
       Array(Array(.1f, .2f, .3f), Array(.4f, .5f, .6f), Array(.7f, .8f, .9f))
 
-    val yExpected = goldenMatMatMul(a, b).flatten
+    val yExpected = golden.Ops.matMul(a, b).flatten
 
     val af = a.map(_.map(Fixed32bp16.fromDouble(_)))
     val bf = b.map(_.map(Fixed32bp16.fromDouble(_)))
 
-    val yf = goldenMatMatMul(af, bf)
+    val yf = golden.Ops.matMul(af, bf)
 
     val y = yf.map(_.map(_.toDouble())).flatten
 

--- a/common/test/src/FixedSpec.scala
+++ b/common/test/src/FixedSpec.scala
@@ -11,7 +11,9 @@ import Numeric.Implicits._
 class FixedSpec extends FlatSpec {
   behavior of "Fixed"
 
-  def goldenMatMatMul[T : Numeric : ClassTag](
+  implicit val numeric = FloatAsIfIntegralWithMAC
+
+  def goldenMatMatMul[T : NumericWithMAC : ClassTag](
       a: Array[Array[T]],
       b: Array[Array[T]]
   ): Array[Array[T]] = {
@@ -21,11 +23,12 @@ class FixedSpec extends FlatSpec {
     if (a.head.length == 0) return Array.empty[Array[T]]
     if (b.head.length == 0) return Array.empty[Array[T]]
     val result =
-      Array.fill(a.length, b.head.length)(implicitly[Numeric[T]].zero)
+      Array.fill(a.length, b.head.length)(implicitly[NumericWithMAC[T]].zero)
     for (i <- a.indices) {
       for (j <- a.head.indices) {
         for (k <- b.head.indices) {
-          result(i)(k) += a(i)(j) * b(j)(k)
+          result(i)(k) =
+            implicitly[NumericWithMAC[T]].mac(a(i)(j), b(j)(k), result(i)(k))
         }
       }
     }
@@ -34,9 +37,13 @@ class FixedSpec extends FlatSpec {
 
   it should "Fixed16bp8 matrix multiplication within error" in {
     val a =
-      Array(Array(1.0, 2.0, 3.0), Array(4.0, 5.0, 6.0), Array(7.0, 8.0, 9.0))
+      Array(
+        Array(1.0f, 2.0f, 3.0f),
+        Array(4.0f, 5.0f, 6.0f),
+        Array(7.0f, 8.0f, 9.0f)
+      )
     val b =
-      Array(Array(.1, .2, .3), Array(.4, .5, .6), Array(.7, .8, .9))
+      Array(Array(.1f, .2f, .3f), Array(.4f, .5f, .6f), Array(.7f, .8f, .9f))
 
     val yExpected = goldenMatMatMul(a, b).flatten
 
@@ -59,9 +66,13 @@ class FixedSpec extends FlatSpec {
 
   it should "Fixed18bp10 matrix multiplication within error" in {
     val a =
-      Array(Array(1.0, 2.0, 3.0), Array(4.0, 5.0, 6.0), Array(7.0, 8.0, 9.0))
+      Array(
+        Array(1.0f, 2.0f, 3.0f),
+        Array(4.0f, 5.0f, 6.0f),
+        Array(7.0f, 8.0f, 9.0f)
+      )
     val b =
-      Array(Array(.1, .2, .3), Array(.4, .5, .6), Array(.7, .8, .9))
+      Array(Array(.1f, .2f, .3f), Array(.4f, .5f, .6f), Array(.7f, .8f, .9f))
 
     val yExpected = goldenMatMatMul(a, b).flatten
 
@@ -84,9 +95,13 @@ class FixedSpec extends FlatSpec {
 
   it should "Fixed32bp16 matrix multiplication within error" in {
     val a =
-      Array(Array(1.0, 2.0, 3.0), Array(4.0, 5.0, 6.0), Array(7.0, 8.0, 9.0))
+      Array(
+        Array(1.0f, 2.0f, 3.0f),
+        Array(4.0f, 5.0f, 6.0f),
+        Array(7.0f, 8.0f, 9.0f)
+      )
     val b =
-      Array(Array(.1, .2, .3), Array(.4, .5, .6), Array(.7, .8, .9))
+      Array(Array(.1f, .2f, .3f), Array(.4f, .5f, .6f), Array(.7f, .8f, .9f))
 
     val yExpected = goldenMatMatMul(a, b).flatten
 

--- a/rtl/src/main/scala/tensil/mem/SizeAndStrideHandler.scala
+++ b/rtl/src/main/scala/tensil/mem/SizeAndStrideHandler.scala
@@ -28,7 +28,7 @@ class SizeAndStrideHandler[
 
   // val in =
   //   if (inputQueue) QueueWithReporting(io.in, 1 << 5, name = name) else io.in
-  val in     = io.in
+  val in     = Queue(io.in, 2)
   val stride = 1.U << in.bits.stride
 
   val sizeCounter    = Counter(depth)

--- a/rtl/src/main/scala/tensil/mem/SizeAndStrideHandler.scala
+++ b/rtl/src/main/scala/tensil/mem/SizeAndStrideHandler.scala
@@ -26,9 +26,7 @@ class SizeAndStrideHandler[
     val out = Decoupled(outGen.cloneType)
   })
 
-  // val in =
-  //   if (inputQueue) QueueWithReporting(io.in, 1 << 5, name = name) else io.in
-  val in     = Queue(io.in, 2)
+  val in     = io.in
   val stride = 1.U << in.bits.stride
 
   val sizeCounter    = Counter(depth)

--- a/rtl/src/main/scala/tensil/mem/StrideHandler.scala
+++ b/rtl/src/main/scala/tensil/mem/StrideHandler.scala
@@ -19,10 +19,10 @@ class StrideHandler[
     val out = Decoupled(outGen.cloneType)
   })
 
-  // what happens when size = 0 but stride > 0?
-  // what happens when size * stride > depth?
+  // TODO
+  //  what happens when size = 0 but stride > 0?
+  //  what happens when size * stride > depth?
 
-  // val in = QueueWithReporting(io.in, 2, name = name)
   val in = io.in
   val handler = Module(
     new SizeAndStrideHandler(

--- a/rtl/src/main/scala/tensil/tcu/Accumulator.scala
+++ b/rtl/src/main/scala/tensil/tcu/Accumulator.scala
@@ -45,7 +45,7 @@ class Accumulator[T <: Data with Num[T]](
   )
   val adder   = Module(new VecAdder(gen, height))
   val control = io.control
-  val input   = io.input
+  val input   = Queue(io.input, 2)
 
   val portA        = mem.io.portA
   val portB        = mem.io.portB

--- a/rtl/src/main/scala/tensil/tcu/Decoder.scala
+++ b/rtl/src/main/scala/tensil/tcu/Decoder.scala
@@ -19,6 +19,7 @@ import tensil.mem.SizeAndStrideHandler
 import tensil.mem.SizeHandler
 import tensil.util.WithLast
 import tensil.util.decoupled.MultiEnqueue
+import tensil.mem.OutQueue
 
 class Decoder(val arch: Architecture, options: TCUOptions = TCUOptions())(
     implicit val platformConfig: PlatformConfig
@@ -176,8 +177,8 @@ class Decoder(val arch: Architecture, options: TCUOptions = TCUOptions())(
   )
   io.memPortA <> memPortAHandler.io.out
   io.memPortB <> memPortBHandler.io.out
-  val memPortA = memPortAHandler.io.in
-  val memPortB = memPortBHandler.io.in
+  val memPortA = OutQueue(memPortAHandler.io.in, 2)
+  val memPortB = OutQueue(memPortBHandler.io.in, 2)
   //// accumulator
   val accInGen  = new AccumulatorMemControlWithSizeWithStride(layout)
   val accOutGen = new AccumulatorMemControl(layout)

--- a/rtl/src/main/scala/tensil/tcu/Decoder.scala
+++ b/rtl/src/main/scala/tensil/tcu/Decoder.scala
@@ -69,7 +69,8 @@ class Decoder(val arch: Architecture, options: TCUOptions = TCUOptions())(
   dontTouch(io.programCounter)
 
   // val instruction = QueueWithReporting(io.instruction, 1 << 1) // 4
-  val instruction = io.instruction
+  val instruction = Queue(io.instruction, 2)
+  // val instruction = io.instruction
 
   // only enqueues when instruction is done. we're just assuming
   // status.io.enq.ready will always be true, hence the 50 element buffer

--- a/rtl/src/main/scala/tensil/tcu/MAC.scala
+++ b/rtl/src/main/scala/tensil/tcu/MAC.scala
@@ -14,9 +14,6 @@ class MAC[T <: Data with Num[T]](val gen: T) extends Module {
     val output      = Output(gen)
     val passthrough = Output(gen)
   })
-  // TODO allow each MAC to have more than one weight stored? This can be another
-  //      top level parameter for the architecture. Means less loading weights
-  //      from DRAM
 
   val weight      = RegInit(util.zero(gen))
   val passthrough = RegInit(util.zero(gen))
@@ -30,7 +27,6 @@ class MAC[T <: Data with Num[T]](val gen: T) extends Module {
     io.output := weight
   }.otherwise {
     output := util.mac(gen, io.mulInput, weight, io.addInput)
-    // output := util.plus(gen, util.times(gen, io.mulInput, weight), io.addInput)
     io.output := output
   }
 }

--- a/rtl/src/main/scala/tensil/tcu/MAC.scala
+++ b/rtl/src/main/scala/tensil/tcu/MAC.scala
@@ -29,7 +29,8 @@ class MAC[T <: Data with Num[T]](val gen: T) extends Module {
     weight := io.addInput
     io.output := weight
   }.otherwise {
-    output := util.plus(gen, util.times(gen, io.mulInput, weight), io.addInput)
+    output := util.mac(gen, io.mulInput, weight, io.addInput)
+    // output := util.plus(gen, util.times(gen, io.mulInput, weight), io.addInput)
     io.output := output
   }
 }

--- a/rtl/src/main/scala/tensil/tcu/SystolicArray.scala
+++ b/rtl/src/main/scala/tensil/tcu/SystolicArray.scala
@@ -39,13 +39,7 @@ class SystolicArray[T <: Data with Num[T]](
   val arrayPropagationDelay = height + width - 1
   val array                 = Module(new InnerSystolicArray(gen, height, width))
 
-  val input = Queue(io.input, 2)
-  // val input = io.input
-  // val input = QueueWithReporting(io.input, 1 << 1) // 4
-  // val input = QueueWithReporting(io.input, 1 << 4)
-  // val weight = QueueWithReporting(io.weight, 2) // 1 + width
-  // val weight  = QueueWithReporting(io.weight, 1 + width)
-  // val control = QueueWithReporting(io.control, 2 + width) // 1 << 5
+  val input   = Queue(io.input, 2)
   val weight  = io.weight
   val control = io.control
   val output = Module(
@@ -64,9 +58,6 @@ class SystolicArray[T <: Data with Num[T]](
   io.ran.bits <> ran.io.deq.bits
   io.ran.valid := ran.io.deq.valid
   ran.io.deq.ready := io.ran.ready && output.io.deq.valid
-
-  // reportThroughput(control, 100, "Array.control")
-  // reportThroughput(input, 100, "Array.input")
 
   val runInput  = control.valid && !control.bits.load && !control.bits.zeroes
   val runZeroes = control.valid && !control.bits.load && control.bits.zeroes

--- a/rtl/src/main/scala/tensil/tcu/SystolicArray.scala
+++ b/rtl/src/main/scala/tensil/tcu/SystolicArray.scala
@@ -39,7 +39,8 @@ class SystolicArray[T <: Data with Num[T]](
   val arrayPropagationDelay = height + width - 1
   val array                 = Module(new InnerSystolicArray(gen, height, width))
 
-  val input = io.input
+  val input = Queue(io.input, 2)
+  // val input = io.input
   // val input = QueueWithReporting(io.input, 1 << 1) // 4
   // val input = QueueWithReporting(io.input, 1 << 4)
   // val weight = QueueWithReporting(io.weight, 2) // 1 + width

--- a/rtl/src/main/scala/tensil/util/package.scala
+++ b/rtl/src/main/scala/tensil/util/package.scala
@@ -176,7 +176,7 @@ package object util {
     (gen, x, y, z) match {
       case (gen: FixedPoint, x: FixedPoint, y: FixedPoint, z: FixedPoint) =>
         macFixedPoint(gen, x.asSInt(), y.asSInt(), z.asSInt()).asInstanceOf[T]
-      case _ => x * y
+      case _ => x * y + z
     }
   }
 

--- a/rtl/src/main/scala/tensil/util/package.scala
+++ b/rtl/src/main/scala/tensil/util/package.scala
@@ -173,7 +173,8 @@ package object util {
   def minus[T <: Data with Num[T]](gen: T, x: T, y: T): T = {
     (gen, x, y) match {
       case (gen: FixedPoint, x: FixedPoint, y: FixedPoint) =>
-        plusFixedPoint(gen, x.asSInt(), -y.asSInt()).asInstanceOf[T]
+        plusFixedPoint(gen, x.asSInt(), 0.S -& y.asSInt())
+          .asInstanceOf[T]
       case _ => x - y
     }
   }

--- a/rtl/src/test/scala/tensil/tcu/DecoderSpec.scala
+++ b/rtl/src/test/scala/tensil/tcu/DecoderSpec.scala
@@ -79,6 +79,8 @@ class DecoderSpec extends FunUnitSpec {
           m.clock.step()
           m.io.tracepoint.expect(false.B)
           m.clock.step()
+          m.io.tracepoint.expect(false.B)
+          m.clock.step()
           m.io.tracepoint.expect(true.B)
         // m.clock.step()
         // m.io.tracepoint.expect(true.B)

--- a/rtl/src/test/scala/tensil/util/UtilPackageTests.scala
+++ b/rtl/src/test/scala/tensil/util/UtilPackageTests.scala
@@ -3,6 +3,7 @@
 
 package tensil.util
 
+import scala.util.Random
 import chisel3._
 import chisel3.experimental.FixedPoint
 import chisel3.util.{Decoupled, Queue}
@@ -13,29 +14,37 @@ import tensil.Fixed16bp8
 import Numeric.Implicits._
 
 class UtilPackageTests extends UnitSpec {
+  private val random          = new Random()
+  private val testCasesNumber = 1000000
+
+  private def next: Float = {
+    random.nextFloat() * (Fixed16bp8.MaxValue.toFloat() - Fixed16bp8.MinValue
+      .toFloat()) + Fixed16bp8.MinValue.toFloat()
+  }
+
+  private def mkPairs(n: Int) = {
+    for (_ <- 0 until n) yield (next, next)
+  }
+
+  private def mkTriples(n: Int) = {
+    for (_ <- 0 until n) yield (next, next, next)
+  }
+
   "mac (fixed point)" should "work" in {
-    class TimesFixedPointModule extends Module {
+    class MACFixedPointModule extends Module {
       val gen = FixedPoint(16.W, 8.BP)
       val io = IO(new Bundle {
         val x      = Input(gen)
         val y      = Input(gen)
         val z      = Input(gen)
         val result = Output(gen)
-        val old    = Output(gen)
       })
 
       io.result := mac(gen, io.x, io.y, io.z)
-      io.old := io.x * io.y
     }
-    val testCases = Array(
-      (-0.1, 0.265625, -0.125),
-      (-0.125, 0.25, 0.265625),
-      (0.1, 0.265625, 0.25),
-      (100.0, 2.65625, -0.1), // overflow saturation
-      (100.0, -2.65625, 0.1), // underflow saturation
-    )
+    val testCases = mkTriples(testCasesNumber)
 
-    test(new TimesFixedPointModule) { m =>
+    test(new MACFixedPointModule) { m =>
       for (tc <- testCases) {
         m.io.x.poke(tc._1.F(16.W, 8.BP))
         m.io.y.poke(tc._2.F(16.W, 8.BP))
@@ -43,14 +52,13 @@ class UtilPackageTests extends UnitSpec {
         m.io.result.expect(
           (Fixed16bp8.numericWithMAC
             .mac(
-              Fixed16bp8.fromDouble(tc._1),
-              Fixed16bp8.fromDouble(tc._2),
-              Fixed16bp8.fromDouble(tc._3)
+              Fixed16bp8.fromFloat(tc._1),
+              Fixed16bp8.fromFloat(tc._2),
+              Fixed16bp8.fromFloat(tc._3)
             ))
             .toFloat
             .F(16.W, 8.BP)
         )
-        println(m.io.old.peek())
       }
     }
   }
@@ -61,29 +69,20 @@ class UtilPackageTests extends UnitSpec {
         val x      = Input(gen)
         val y      = Input(gen)
         val result = Output(gen)
-        val old    = Output(gen)
       })
 
       io.result := times(gen, io.x, io.y)
-      io.old := io.x * io.y
     }
-    val testCases = Array(
-      (-0.1, 0.265625),
-      (-0.125, 0.25),
-      (0.1, 0.265625),
-      (100.0, 2.65625),  // overflow saturation
-      (100.0, -2.65625), // underflow saturation
-    )
+    val testCases = mkPairs(testCasesNumber)
 
     test(new TimesFixedPointModule) { m =>
       for (tc <- testCases) {
         m.io.x.poke(tc._1.F(16.W, 8.BP))
         m.io.y.poke(tc._2.F(16.W, 8.BP))
         m.io.result.expect(
-          (Fixed16bp8.fromDouble(tc._1) * Fixed16bp8.fromDouble(tc._2)).toFloat
+          (Fixed16bp8.fromFloat(tc._1) * Fixed16bp8.fromFloat(tc._2)).toFloat
             .F(16.W, 8.BP)
         )
-        println(m.io.old.peek())
       }
     }
   }
@@ -95,29 +94,20 @@ class UtilPackageTests extends UnitSpec {
         val x      = Input(gen)
         val y      = Input(gen)
         val result = Output(gen)
-        val old    = Output(gen)
       })
 
       io.result := plus(gen, io.x, io.y)
-      io.old := io.x + io.y
     }
-    val testCases = Array(
-      (-0.1, 0.265625),
-      (-0.125, 0.25),
-      (0.1, 0.265625),
-      (100.0, 100.0),   // overflow saturation
-      (-100.0, -100.0), // underflow saturation
-    )
+    val testCases = mkPairs(testCasesNumber)
 
     test(new PlusFixedPointModule) { m =>
       for (tc <- testCases) {
         m.io.x.poke(tc._1.F(16.W, 8.BP))
         m.io.y.poke(tc._2.F(16.W, 8.BP))
         m.io.result.expect(
-          (Fixed16bp8.fromDouble(tc._1) + Fixed16bp8.fromDouble(tc._2)).toFloat
+          (Fixed16bp8.fromFloat(tc._1) + Fixed16bp8.fromFloat(tc._2)).toFloat
             .F(16.W, 8.BP)
         )
-        println(m.io.old.peek())
       }
     }
   }
@@ -129,29 +119,20 @@ class UtilPackageTests extends UnitSpec {
         val x      = Input(gen)
         val y      = Input(gen)
         val result = Output(gen)
-        val old    = Output(gen)
       })
 
       io.result := minus(gen, io.x, io.y)
-      io.old := io.x - io.y
     }
-    val testCases = Array(
-      (-0.1, 0.265625),
-      (-0.125, 0.25),
-      (0.1, 0.265625),
-      (100.0, -100.0), // overflow saturation
-      (-100.0, 100.0), // underflow saturation
-    )
+    val testCases = mkPairs(testCasesNumber)
 
     test(new MinusFixedPointModule) { m =>
       for (tc <- testCases) {
         m.io.x.poke(tc._1.F(16.W, 8.BP))
         m.io.y.poke(tc._2.F(16.W, 8.BP))
         m.io.result.expect(
-          (Fixed16bp8.fromDouble(tc._1) - Fixed16bp8.fromDouble(tc._2)).toFloat
+          (Fixed16bp8.fromFloat(tc._1) - Fixed16bp8.fromFloat(tc._2)).toFloat
             .F(16.W, 8.BP)
         )
-        println(m.io.old.peek())
       }
     }
   }

--- a/sim/src/zynq/tcu/DRAM.scala
+++ b/sim/src/zynq/tcu/DRAM.scala
@@ -222,7 +222,7 @@ class DRAMWithBase[T](
   }
 
   def readFloatScalar(address: Long): Float = {
-    base.numeric.toFloat(readScalar(address))
+    base.numericWithMAC.toFloat(readScalar(address))
   }
 
   def writeFloatScalar(address: Long, scalar: Float): Unit = {

--- a/sim/test/src/zynq/tcu/AXIWrapperTCUSpec.scala
+++ b/sim/test/src/zynq/tcu/AXIWrapperTCUSpec.scala
@@ -500,13 +500,13 @@ class AXIWrapperTCUSpec extends FunUnitSpec {
               .filter(_ <= arch.accumulatorDepth)
 
           val tests = Seq(
-            /*() => xor4(batchSize = 1),
+            () => xor4(batchSize = 1),
             () => xor4(batchSize = 2),
-            () => xor4(batchSize = 4),*/
+            () => xor4(batchSize = 4),
             () => resnet(batchSize = 1, inputSize = 1),
-            /*() => resnet(batchSize = 10, inputSize = 10),*/
-          ) /*++ dataMoveSizes.map(size => () => dataMove(size, 4, true)) ++
-            dataMoveSizes.map(size => () => dataMove(size, 4, false))*/
+            () => resnet(batchSize = 10, inputSize = 10),
+          ) ++ dataMoveSizes.map(size => () => dataMove(size, 4, true)) ++
+            dataMoveSizes.map(size => () => dataMove(size, 4, false))
 
           for (t <- tests) {
             if (randomizeDrams) {

--- a/sim/test/src/zynq/tcu/AXIWrapperTCUSpec.scala
+++ b/sim/test/src/zynq/tcu/AXIWrapperTCUSpec.scala
@@ -222,17 +222,17 @@ class AXIWrapperTCUSpec extends FunUnitSpec {
                 )
 
                 // setup compiler output streams
-                val modelFileName = "./models/resnet20v2_cifar.pb"
+                val modelFileName = "./models/resnet20v2_cifar.onnx"
                 val model         = new FileInputStream(modelFileName)
                 val consts        = new ByteArrayOutputStream()
                 val program       = new ByteArrayOutputStream()
 
                 // run the compiler
                 val compilerResult = Compiler.compileStreamToStreams(
-                  "resnet20v2_cifar_pb",
+                  "resnet20v2_cifar_onnx",
                   Compiler.getModelSourceType(modelFileName),
                   model,
-                  List("Identity"),
+                  List("Identity:0"),
                   program,
                   consts,
                   options
@@ -500,13 +500,13 @@ class AXIWrapperTCUSpec extends FunUnitSpec {
               .filter(_ <= arch.accumulatorDepth)
 
           val tests = Seq(
-            () => xor4(batchSize = 1),
+            /*() => xor4(batchSize = 1),
             () => xor4(batchSize = 2),
-            () => xor4(batchSize = 4),
+            () => xor4(batchSize = 4),*/
             () => resnet(batchSize = 1, inputSize = 1),
-            () => resnet(batchSize = 10, inputSize = 10),
-          ) ++ dataMoveSizes.map(size => () => dataMove(size, 4, true)) ++
-            dataMoveSizes.map(size => () => dataMove(size, 4, false))
+            /*() => resnet(batchSize = 10, inputSize = 10),*/
+          ) /*++ dataMoveSizes.map(size => () => dataMove(size, 4, true)) ++
+            dataMoveSizes.map(size => () => dataMove(size, 4, false))*/
 
           for (t <- tests) {
             if (randomizeDrams) {

--- a/tools/src/tensil/tools/golden/Processor.scala
+++ b/tools/src/tensil/tools/golden/Processor.scala
@@ -11,7 +11,7 @@ import scala.reflect.ClassTag
 
 import tensil.tools.data.Tensor
 import tensil.tools.{TraceContext}
-import tensil.{Architecture, ArchitectureDataTypeWithBase, TablePrinter}
+import tensil.{Architecture, ArchitectureDataTypeWithBase, TablePrinter, golden}
 import tensil.tools.compiler.{
   LoadWeightsFlags,
   SIMDFlags,
@@ -22,8 +22,9 @@ import tensil.tools.compiler.{
   SIMDDestination,
   MemoryAddressRaw
 }
+import tensil.NumericWithMAC
 
-class Processor[T : Numeric : ClassTag](
+class Processor[T : NumericWithMAC : ClassTag](
     dataType: ArchitectureDataTypeWithBase[T],
     arch: Architecture
 ) {
@@ -184,7 +185,7 @@ class Processor[T : Numeric : ClassTag](
                               })
           )
 
-        val y = Tensor.goldenMatMatMul(x, currentWeights)
+        val y = golden.Ops.matMul(x, currentWeights)
 
         for (j <- 0 until arch.arraySize)
           if ((flags & MatMulFlags.Accumulate) != 0)

--- a/tools/test/src/tools/GoldenProcessorHelper.scala
+++ b/tools/test/src/tools/GoldenProcessorHelper.scala
@@ -7,7 +7,13 @@ import java.io._
 import scala.reflect.ClassTag
 import tensil.tools.golden.{Processor, ExecutiveTraceContext}
 import scala.collection.mutable
-import tensil.{Architecture, ArchitectureDataType, ArchitectureDataTypeWithBase}
+import tensil.{
+  Architecture,
+  ArchitectureDataType,
+  ArchitectureDataTypeWithBase,
+  NumericWithMAC,
+  FloatAsIfIntegralWithMAC
+}
 import tensil.tools.model.Model
 import tensil.tools.golden.ExecutiveTrace
 
@@ -22,6 +28,8 @@ object GoldenProcessorHelper {
 
     model.arch.dataType.name match {
       case ArchitectureDataType.FLOAT32.name =>
+        implicit val numericWithMAC = FloatAsIfIntegralWithMAC
+
         doTest(
           ArchitectureDataType.FLOAT32,
           model,
@@ -163,7 +171,7 @@ object GoldenProcessorHelper {
     else
       1
 
-  private def doTest[T : Numeric : ClassTag](
+  private def doTest[T : NumericWithMAC : ClassTag](
       dataType: ArchitectureDataTypeWithBase[T],
       model: Model,
       inputBatchSize: Int,


### PR DESCRIPTION
This change

- merges fixed point multiply and add into a single operation called mac, which avoids computing the saturation handling twice
- adds various input buffers to modules as needed to break up long routes

Ultra96v2 now makes timing at 150MHz with a WNS of 0.114ns. The longest routes now pass through the saturation handling in the acc ALUs.

Additional changes

- Re-use fixed-point MAC for times and plus;
- Golden MAC implementation to match hardware;
- Test fixed point with fuzzing;
- Fix fixed-point minus (discovered by fuzzing);
- Use ONNX ResNet-20 in simulation test;
- Use Mill fork args to allow simulation test with sufficient memory;