### PR TITLE
Fix compiler crash on non-square convolutions

### DIFF
--- a/tools/test/src/tools/CompilerSpec.scala
+++ b/tools/test/src/tools/CompilerSpec.scala
@@ -1385,7 +1385,7 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile TF Conv2D (VALID padding) 3x5x4 image with 2x2x4x4 kernel" in {
+  it should "Compile TF Conv2D (VALID padding) 3x5x4 image with 3x2x4x4 kernel" in {
     val name = "conv2d_non_square_4x4_valid"
     val options = CompilerOptions(
       arch = Conv2DTiny4x4Architecure,
@@ -1402,7 +1402,7 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile TF Conv2D (SAME padding) 3x5x4 image with 2x2x4x4 kernel" in {
+  it should "Compile TF Conv2D (SAME padding) 3x5x4 image with 3x2x4x4 kernel" in {
     val name    = "conv2d_non_square_4x4_same"
     val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
 
@@ -1416,7 +1416,7 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile tiled TF Conv2D (VALID padding) 3x5x4 image with 2x2x4x4 kernel" in {
+  it should "Compile tiled TF Conv2D (VALID padding) 3x5x4 image with 3x2x4x4 kernel" in {
     val name = "conv2d_non_square_4x4_valid_tiled"
     val options = CompilerOptions(
       arch = Conv2DTiny2x2Architecure,
@@ -1433,7 +1433,7 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile tiled TF Conv2D (SAME padding) 3x5x4 image with 2x2x4x4 kernel" in {
+  it should "Compile tiled TF Conv2D (SAME padding) 3x5x4 image with 3x2x4x4 kernel" in {
     val name    = "conv2d_non_square_4x4_same_tiled"
     val options = CompilerOptions(arch = Conv2DTiny2x2Architecure)
 
@@ -1447,7 +1447,7 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile oversized TF Conv2D (VALID padding) 3x5x4 image with 2x2x4x4 kernel" in {
+  it should "Compile oversized TF Conv2D (VALID padding) 3x5x4 image with 3x2x4x4 kernel" in {
     val name = "conv2d_non_square_4x4_valid_oversized"
     val options = CompilerOptions(
       arch = Conv2DTiny8x8Architecure,
@@ -1464,7 +1464,7 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile oversized TF Conv2D (SAME padding) 3x5x4 image with 2x2x4x4 kernel" in {
+  it should "Compile oversized TF Conv2D (SAME padding) 3x5x4 image with 3x2x4x4 kernel" in {
     val name    = "conv2d_non_square_4x4_same_oversized"
     val options = CompilerOptions(arch = Conv2DTiny8x8Architecure)
 
@@ -1570,7 +1570,7 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile ONNX Conv2D (VALID padding) 3x5x4 image with 2x2x4x4 kernel" in {
+  it should "Compile ONNX Conv2D (VALID padding) 3x5x4 image with 3x2x4x4 kernel" in {
     val name = "conv2d_non_square_4x4_valid"
     val options = CompilerOptions(
       arch = Conv2DTiny4x4Architecure,
@@ -1587,7 +1587,7 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile ONNX Conv2D (SAME padding) 3x5x4 image with 2x2x4x4 kernel" in {
+  it should "Compile ONNX Conv2D (SAME padding) 3x5x4 image with 3x2x4x4 kernel" in {
     val name    = "conv2d_non_square_4x4_same"
     val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
 

--- a/tools/test/src/tools/CompilerSpec.scala
+++ b/tools/test/src/tools/CompilerSpec.scala
@@ -1296,6 +1296,20 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
+  it should "Compile TF Conv2D (SAME padding, 2x2 strides) 3x3x4 image with 2x2x4x4 kernel" in {
+    val name    = "conv2d_4x4_same_stride_2"
+    val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_4x4_same_stride_2.pb",
+      List("Identity_1"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
   it should "Compile TF tiled Conv2D (VALID padding) 3x3x4 image with 2x2x4x4 kernel" in {
     val name    = "conv2d_4x4_valid_tiled"
     val options = CompilerOptions(arch = Conv2DTiny2x2Architecure)

--- a/tools/test/src/tools/CompilerSpec.scala
+++ b/tools/test/src/tools/CompilerSpec.scala
@@ -1296,20 +1296,6 @@ class CompilerSpec extends FlatSpec {
     GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
   }
 
-  it should "Compile TF Conv2D (SAME padding, 2x2 strides) 3x3x4 image with 2x2x4x4 kernel" in {
-    val name    = "conv2d_4x4_same_stride_2"
-    val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
-
-    Compiler.compile(
-      name,
-      s"${Models}/conv2d_4x4_same_stride_2.pb",
-      List("Identity_1"),
-      options
-    )
-
-    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
-  }
-
   it should "Compile TF tiled Conv2D (VALID padding) 3x3x4 image with 2x2x4x4 kernel" in {
     val name    = "conv2d_4x4_valid_tiled"
     val options = CompilerOptions(arch = Conv2DTiny2x2Architecure)
@@ -1393,6 +1379,222 @@ class CompilerSpec extends FlatSpec {
       name,
       s"${Models}/conv2d_4x4_same_relu_2x2_maxpool_valid_stride_1.pb",
       List("Identity_1"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile TF Conv2D (VALID padding) 3x5x4 image with 2x2x4x4 kernel" in {
+    val name = "conv2d_non_square_4x4_valid"
+    val options = CompilerOptions(
+      arch = Conv2DTiny4x4Architecure,
+      printSummary = true
+    )
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_non_square_4x4_valid.pb",
+      List("Identity_1"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile TF Conv2D (SAME padding) 3x5x4 image with 2x2x4x4 kernel" in {
+    val name    = "conv2d_non_square_4x4_same"
+    val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_non_square_4x4_same.pb",
+      List("Identity_1"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile tiled TF Conv2D (VALID padding) 3x5x4 image with 2x2x4x4 kernel" in {
+    val name = "conv2d_non_square_4x4_valid_tiled"
+    val options = CompilerOptions(
+      arch = Conv2DTiny2x2Architecure,
+      printSummary = true
+    )
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_non_square_4x4_valid.pb",
+      List("Identity_1"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile tiled TF Conv2D (SAME padding) 3x5x4 image with 2x2x4x4 kernel" in {
+    val name    = "conv2d_non_square_4x4_same_tiled"
+    val options = CompilerOptions(arch = Conv2DTiny2x2Architecure)
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_non_square_4x4_same.pb",
+      List("Identity_1"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile oversized TF Conv2D (VALID padding) 3x5x4 image with 2x2x4x4 kernel" in {
+    val name = "conv2d_non_square_4x4_valid_oversized"
+    val options = CompilerOptions(
+      arch = Conv2DTiny8x8Architecure,
+      printSummary = true
+    )
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_non_square_4x4_valid.pb",
+      List("Identity_1"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile oversized TF Conv2D (SAME padding) 3x5x4 image with 2x2x4x4 kernel" in {
+    val name    = "conv2d_non_square_4x4_same_oversized"
+    val options = CompilerOptions(arch = Conv2DTiny8x8Architecure)
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_non_square_4x4_same.pb",
+      List("Identity_1"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile ONNX Conv2D (VALID padding) 3x3x4 image with 2x2x4x4 kernel" in {
+    val name = "conv2d_4x4_valid"
+    val options = CompilerOptions(
+      arch = Conv2DTiny4x4Architecure,
+      printSummary = true
+    )
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_4x4_valid.onnx",
+      List("Identity_1:0"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile ONNX Conv2D (VALID padding, 2x2 strides) 3x3x4 image with 2x2x4x4 kernel" in {
+    val name    = "conv2d_4x4_valid_stride_2"
+    val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_4x4_valid_stride_2.onnx",
+      List("Conv2D:0"), // Skip Reshape added by ONNX converter
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile ONNX Conv2D (SAME padding) 3x3x4 image with 2x2x4x4 kernel" in {
+    val name    = "conv2d_4x4_same"
+    val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_4x4_same.onnx",
+      List("Identity_1:0"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile ONNX Conv2D (SAME padding, 2x2 strides) 3x3x4 image with 2x2x4x4 kernel" in {
+    val name    = "conv2d_4x4_same_stride_2"
+    val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_4x4_same_stride_2.onnx",
+      List("Identity_1:0"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile ONNX Conv2D (SAME padding) 3x3x4 image with 2x2x4x4 kernel, Relu, MaxPool (VALID padding)" in {
+    val name = "conv2d_4x4_same_relu_2x2_maxpool_valid_stride_2"
+    val options = CompilerOptions(
+      arch = Conv2DTiny4x4Architecure,
+      printSummary = true
+    )
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_4x4_same_relu_2x2_maxpool_valid_stride_2.onnx",
+      List("MaxPool2d:0"), // Skip Reshape added by ONNX converter
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile ONNX Conv2D (SAME padding) 3x3x4 image with 2x2x4x4 kernel, Relu, MaxPool (VALID padding, 1x1 stride)" in {
+    val name = "conv2d_4x4_same_relu_2x2_maxpool_valid_stride_1"
+    val options = CompilerOptions(
+      arch = Conv2DTiny4x4Architecure,
+    )
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_4x4_same_relu_2x2_maxpool_valid_stride_1.onnx",
+      List("Identity_1:0"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile ONNX Conv2D (VALID padding) 3x5x4 image with 2x2x4x4 kernel" in {
+    val name = "conv2d_non_square_4x4_valid"
+    val options = CompilerOptions(
+      arch = Conv2DTiny4x4Architecure,
+      printSummary = true
+    )
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_non_square_4x4_valid.onnx",
+      List("Identity_1:0"),
+      options
+    )
+
+    GoldenProcessorHelper.test(name, inputBatchSize = options.inputBatchSize)
+  }
+
+  it should "Compile ONNX Conv2D (SAME padding) 3x5x4 image with 2x2x4x4 kernel" in {
+    val name    = "conv2d_non_square_4x4_same"
+    val options = CompilerOptions(arch = Conv2DTiny4x4Architecure)
+
+    Compiler.compile(
+      name,
+      s"${Models}/conv2d_non_square_4x4_same.onnx",
+      List("Identity_1:0"),
       options
     )
 

--- a/tools/test/src/tools/Conv2D.scala
+++ b/tools/test/src/tools/Conv2D.scala
@@ -15,7 +15,9 @@ object Conv2D {
       height: Int,
       width: Int
   ): InputStream =
-    new ByteArrayInputStream(prepareInputBytes(dataType, arraySize, height, width))
+    new ByteArrayInputStream(
+      prepareInputBytes(dataType, arraySize, height, width)
+    )
 
   def prepareInputBytes(
       dataType: ArchitectureDataType,
@@ -102,26 +104,27 @@ object Conv2D {
 
   val ValidNonSquareStride1Pixels = Array(
     Array(
-      Array(17152.0f, 17368.0f, 17584.0f, 17800.0f),
-      Array(21376.0f, 21656.0f, 21936.0f, 22216.0f),
-      Array(25600.0f, 25944.0f, 26288.0f, 26632.0f),
-      Array(29824.0f, 30232.0f, 30640.0f, 31048.0f)
-    ),
-    Array(
-      Array(38272.0f, 38808.0f, 39344.0f, 39880.0f),
-      Array(42496.0f, 43096.0f, 43696.0f, 44296.0f),
-      Array(46720.0f, 47384.0f, 48048.0f, 48712.0f),
-      Array(50944.0f, 51672.0f, 52400.0f, 53128.0f)
+      Array(56992.0f, 57514.0f, 58120.0f, 58684.0f),
+      Array(64864.0f, 65478.0f, 66184.0f, 66844.0f),
+      Array(72736.0f, 73442.0f, 74248.0f, 75004.0f),
+      Array(80608.0f, 81406.0f, 82312.0f, 83164.0f)
     )
   )
 
   val SameNonSquareStride1Pixels = Array(
     Array(
-      Array(17152.0f, 17368.0f, 17584.0f, 17800.0f),
-      Array(21376.0f, 21656.0f, 21936.0f, 22216.0f),
-      Array(25600.0f, 25944.0f, 26288.0f, 26632.0f),
-      Array(29824.0f, 30232.0f, 30640.0f, 31048.0f),
-      Array(14080.0f, 14300.0f, 14520.0f, 14740.0f)
+      Array(24064.0f, 24258.0f, 24496.0f, 24712.0f),
+      Array(30336.0f, 30590.0f, 30896.0f, 31176.0f),
+      Array(36608.0f, 36922.0f, 37296.0f, 37640.0f),
+      Array(42880.0f, 43254.0f, 43696.0f, 44104.0f),
+      Array(21120.0f, 21302.0f, 21560.0f, 21780.0f)
+    ),
+    Array(
+      Array(56992.0f, 57514.0f, 58120.0f, 58684.0f),
+      Array(64864.0f, 65478.0f, 66184.0f, 66844.0f),
+      Array(72736.0f, 73442.0f, 74248.0f, 75004.0f),
+      Array(80608.0f, 81406.0f, 82312.0f, 83164.0f),
+      Array(38480.0f, 38872.0f, 39380.0f, 39830.0f)
     ),
     Array(
       Array(38272.0f, 38808.0f, 39344.0f, 39880.0f),
@@ -129,13 +132,6 @@ object Conv2D {
       Array(46720.0f, 47384.0f, 48048.0f, 48712.0f),
       Array(50944.0f, 51672.0f, 52400.0f, 53128.0f),
       Array(23360.0f, 23740.0f, 24120.0f, 24500.0f)
-    ),
-    Array(
-      Array(17568.0f, 17916.0f, 18264.0f, 18612.0f),
-      Array(19168.0f, 19548.0f, 19928.0f, 20308.0f),
-      Array(20768.0f, 21180.0f, 21592.0f, 22004.0f),
-      Array(22368.0f, 22812.0f, 23256.0f, 23700.0f),
-      Array(9680.0f, 9910.0f, 10140.0f, 10370.0f)
     )
   )
 

--- a/tools/test/src/tools/Conv2D.scala
+++ b/tools/test/src/tools/Conv2D.scala
@@ -12,25 +12,29 @@ object Conv2D {
   def prepareInputStream(
       dataType: ArchitectureDataType,
       arraySize: Int,
+      height: Int,
+      width: Int
   ): InputStream =
-    new ByteArrayInputStream(prepareInputBytes(dataType, arraySize))
+    new ByteArrayInputStream(prepareInputBytes(dataType, arraySize, height, width))
 
   def prepareInputBytes(
       dataType: ArchitectureDataType,
-      arraySize: Int
+      arraySize: Int,
+      height: Int,
+      width: Int
   ): Array[Byte] = {
     val inputPrep           = new ByteArrayOutputStream()
     val inputPrepDataStream = new DataOutputStream(inputPrep)
 
-    def writePixel(k: Int, l: Int): Unit = {
+    def writePixel(base: Int): Unit = {
       for (i <- 0 until 4)
-        dataType.writeFloatConst(i + (l + k * 3) * 4, inputPrepDataStream)
+        dataType.writeFloatConst(i + base * 4, inputPrepDataStream)
       for (i <- 0 until arraySize - 4)
         dataType.writeFloatConst(0f, inputPrepDataStream)
     }
 
-    for (k <- 0 until 3; l <- 0 until 3)
-      writePixel(k, l)
+    for (k <- 0 until height; l <- 0 until width)
+      writePixel(l + k * width)
 
     inputPrep.toByteArray()
   }
@@ -95,6 +99,45 @@ object Conv2D {
       Array(28800.0f, 29208.0f, 29616.0f, 30024.0f)
     )
   );
+
+  val ValidNonSquareStride1Pixels = Array(
+    Array(
+      Array(17152.0f, 17368.0f, 17584.0f, 17800.0f),
+      Array(21376.0f, 21656.0f, 21936.0f, 22216.0f),
+      Array(25600.0f, 25944.0f, 26288.0f, 26632.0f),
+      Array(29824.0f, 30232.0f, 30640.0f, 31048.0f)
+    ),
+    Array(
+      Array(38272.0f, 38808.0f, 39344.0f, 39880.0f),
+      Array(42496.0f, 43096.0f, 43696.0f, 44296.0f),
+      Array(46720.0f, 47384.0f, 48048.0f, 48712.0f),
+      Array(50944.0f, 51672.0f, 52400.0f, 53128.0f)
+    )
+  )
+
+  val SameNonSquareStride1Pixels = Array(
+    Array(
+      Array(17152.0f, 17368.0f, 17584.0f, 17800.0f),
+      Array(21376.0f, 21656.0f, 21936.0f, 22216.0f),
+      Array(25600.0f, 25944.0f, 26288.0f, 26632.0f),
+      Array(29824.0f, 30232.0f, 30640.0f, 31048.0f),
+      Array(14080.0f, 14300.0f, 14520.0f, 14740.0f)
+    ),
+    Array(
+      Array(38272.0f, 38808.0f, 39344.0f, 39880.0f),
+      Array(42496.0f, 43096.0f, 43696.0f, 44296.0f),
+      Array(46720.0f, 47384.0f, 48048.0f, 48712.0f),
+      Array(50944.0f, 51672.0f, 52400.0f, 53128.0f),
+      Array(23360.0f, 23740.0f, 24120.0f, 24500.0f)
+    ),
+    Array(
+      Array(17568.0f, 17916.0f, 18264.0f, 18612.0f),
+      Array(19168.0f, 19548.0f, 19928.0f, 20308.0f),
+      Array(20768.0f, 21180.0f, 21592.0f, 22004.0f),
+      Array(22368.0f, 22812.0f, 23256.0f, 23700.0f),
+      Array(9680.0f, 9910.0f, 10140.0f, 10370.0f)
+    )
+  )
 
   def assertOutput(
       dataType: ArchitectureDataType,

--- a/tools/test/src/tools/GoldenProcessorHelper.scala
+++ b/tools/test/src/tools/GoldenProcessorHelper.scala
@@ -215,8 +215,6 @@ object GoldenProcessorHelper {
       prepareInputStream(model.name, dataType, model.arch.arraySize, count)
 
     for (_ <- 0 until count / inputBatchSize) {
-      println(input.size)
-
       processor.writeDRAM0(
         input.base until input.base + input.size,
         new DataInputStream(inputStream)

--- a/tools/test/src/tools/GoldenProcessorHelper.scala
+++ b/tools/test/src/tools/GoldenProcessorHelper.scala
@@ -85,8 +85,10 @@ object GoldenProcessorHelper {
       Mnist.prepareInputStream(arraySize, count, false)
     else if (modelName.startsWith("maxpool"))
       MaxPool.prepareInputStream(dataType, arraySize)
+    else if (modelName.startsWith("conv2d_non_square"))
+      Conv2D.prepareInputStream(dataType, arraySize, 3, 5)
     else if (modelName.startsWith("conv2d"))
-      Conv2D.prepareInputStream(dataType, arraySize)
+      Conv2D.prepareInputStream(dataType, arraySize, 3, 3)
     else if (modelName.startsWith("cnn_mnist"))
       Mnist.prepareInputStream(arraySize, count, true)
     else if (modelName.startsWith("resnet20v2"))
@@ -119,11 +121,29 @@ object GoldenProcessorHelper {
     else if (modelName.matches("conv2d_4x4_valid((_tiled)|(_oversized))?"))
       Conv2D.assertOutput(dataType, arraySize, bytes, Conv2D.ValidStride1Pixels)
     else if (
+      modelName.matches("conv2d_non_square_4x4_valid((_tiled)|(_oversized))?")
+    )
+      Conv2D.assertOutput(
+        dataType,
+        arraySize,
+        bytes,
+        Conv2D.ValidNonSquareStride1Pixels
+      )
+    else if (
       modelName.matches("conv2d_4x4_valid_stride_2((_tiled)|(_oversized))?")
     )
       Conv2D.assertOutput(dataType, arraySize, bytes, Conv2D.ValidStride2Pixels)
     else if (modelName.matches("conv2d_4x4_same((_tiled)|(_oversized))?"))
       Conv2D.assertOutput(dataType, arraySize, bytes, Conv2D.SameStride1Pixels)
+    else if (
+      modelName.matches("conv2d_non_square_4x4_same((_tiled)|(_oversized))?")
+    )
+      Conv2D.assertOutput(
+        dataType,
+        arraySize,
+        bytes,
+        Conv2D.SameNonSquareStride1Pixels
+      )
     else if (
       modelName.matches("conv2d_4x4_same_stride_2((_tiled)|(_oversized))?")
     )
@@ -195,6 +215,8 @@ object GoldenProcessorHelper {
       prepareInputStream(model.name, dataType, model.arch.arraySize, count)
 
     for (_ <- 0 until count / inputBatchSize) {
+      println(input.size)
+
       processor.writeDRAM0(
         input.base until input.base + input.size,
         new DataInputStream(inputStream)


### PR DESCRIPTION
- Fix ONNX frontend parsing `pads` argument in `Conv` operation;
- Simplify/unify padding, strides and kernel size parsing in frontends;
- Test 2D convolutions with non-square kernels and activations;
- Test ONNX frontend with all convolutions cases.