### PR TITLE
Fix two cycle read/write bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,26 @@ rm main.tar.gz
 ./mill __.test -l org.scalatest.tags.Slow
 ```
 
+To run a single RTL test in, for example, the Accumulator module, and also output a VCD file, do:
+
+```
+./mill rtl.test.testOnly tensil.tcu.AccumulatorSpec -- -DwriteVcd=true -z "should accumulate values"
+```
+
+### View VCD files
+
+To view the latest VCD file generated:
+
+```
+./scripts/gtkwave/display-latest-vcd.py
+```
+
+To view a specific VCD file:
+
+```
+./scripts/gtkwave/display-vcd.sh <vcd_file>
+```
+
 ## Get help
 
 - Say hello and ask a question on our [Discord](https://discord.gg/TSw34H3PXr)

--- a/rtl/src/main/scala/tensil/mem/DualPortMem.scala
+++ b/rtl/src/main/scala/tensil/mem/DualPortMem.scala
@@ -36,12 +36,13 @@ class DualPortMem[T <: Data](
   connectPort(io.portA, mem.io.portA, "A")
   connectPort(io.portB, mem.io.portB, "B")
 
-  def connectPort(port: Port[T], inner: InnerPort[T], portName: String) {
+  def connectPort(
+      port: Port[T],
+      inner: InnerPort[T],
+      portName: String
+  ): Unit = {
     val control = port.control
     val input   = port.input
-
-    // reportThroughput(control, 100, "Mem" + portName + ".control")
-    // reportThroughput(input, 100, "Mem" + portName + ".input")
 
     val readDelay        = 1
     val outputBufferSize = 2

--- a/rtl/src/main/scala/tensil/util/decoupled/Demux.scala
+++ b/rtl/src/main/scala/tensil/util/decoupled/Demux.scala
@@ -19,12 +19,7 @@ class Demux[T <: Data](
     val out = Vec(n, Decoupled(gen))
   })
 
-  // val in  = QueueWithReporting(io.in, 1 << 1, name=name) // 7
-  // val in  = QueueWithReporting(io.in, 1 << 5, name = name) // 7
-  // val in = Queue(io.in, 2, flow = true)
-  val in = io.in
-  // val sel = QueueWithReporting(io.sel, controlQueueSize, name = name)
-  // val sel = Queue(io.sel, 2, flow = true)
+  val in  = io.in
   val sel = io.sel
 
   for (i <- 0 until n) {

--- a/rtl/src/main/scala/tensil/util/decoupled/VecAdder.scala
+++ b/rtl/src/main/scala/tensil/util/decoupled/VecAdder.scala
@@ -14,8 +14,7 @@ class VecAdder[T <: Data with Num[T]](gen: T, size: Int) extends Module {
     val output = Decoupled(Vec(size, gen))
   })
 
-  val left = Queue(io.left, 1, pipe = true, flow = true)
-  // val right = io.right
+  val left  = Queue(io.left, 1, pipe = true, flow = true)
   val right = Queue(io.right, 1, pipe = true, flow = true)
 
   for (i <- 0 until size) {

--- a/sim/test/src/zynq/tcu/AXIWrapperTCUSpec.scala
+++ b/sim/test/src/zynq/tcu/AXIWrapperTCUSpec.scala
@@ -313,7 +313,7 @@ class AXIWrapperTCUSpec extends FunUnitSpec {
                   }
 
                   // wait until it's done
-                  for (l <- 0 until 6700000 * batchSize) {
+                  for (l <- 0 until 3700000 * batchSize) {
 
                     if (l % 1000 == 0)
                       println(s"CYCLE: $l")


### PR DESCRIPTION
This change adds transparent queues to all the control queues in the accumulator modules to unblock control flow. When a control queue needs to address more than one subordinate before proceeding, we use a multi enqueue to handle this transaction. This works well when all the subordinates are engaged at the same stage in the data pipeline, but when one subordinate operates at a later stage, it can cause earlier subordinates to have to wait for it unnecessarily. By adding tiny transparent queues to all the inputs to a multi enqueue, we cut this dependency because the later subordinates control flow can simply buffer up. In the future, when we add a multi enqueue that addresses subordinates that might be separated by up to N cycles in the pipeline, we should add a transparent queue of N elements to each control input.

This change also adds a helpful command to the readme and tidies up a few comment messes.