### PR TITLE
Fix matmul / acc delay

### DIFF
--- a/rtl/src/main/scala/tensil/mem/DualPortMemWithProtection.scala
+++ b/rtl/src/main/scala/tensil/mem/DualPortMemWithProtection.scala
@@ -1,0 +1,54 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright © 2019-2022 Tensil AI Company */
+
+package tensil.mem
+
+import chisel3._
+import chisel3.util.{Decoupled, Queue, log2Ceil}
+import tensil.PlatformConfig
+
+class DualPortMemWithProtection[T <: Data](
+    val gen: T,
+    val depth: Long,
+    val strideDepth: Int,
+    debug: Boolean = false,
+    name: String = "mem",
+)(implicit val platformConfig: PlatformConfig)
+    extends Module {
+  val addressType = UInt(log2Ceil(depth).W)
+
+  val io = IO(new Bundle {
+    val portA          = new PortWithStride(gen, depth, strideDepth)
+    val portB          = new PortWithStride(gen, depth, strideDepth)
+    val tracepoint     = Input(Bool())
+    val programCounter = Input(UInt(32.W))
+  })
+
+  val m = Module(new DualPortMem(gen, depth, debug = debug, name = name))
+
+  // make a queue for each input port
+  // whenever we enqueue new control inputs, we check
+  // this module should include the size and stride handler stuff
+
+  val controlBufferSize = 10
+
+  val portA = Queue(io.portA.control, controlBufferSize)
+  val portB = Queue(io.portB.control, controlBufferSize)
+
+}
+
+class BlockTable(depth: Long, strideDepth: Int) extends Module {
+  val io = IO(new Bundle {
+    val add =
+      Flipped(Decoupled(new MemControlWithStride(depth, strideDepth: Int)))
+    val remove =
+      Flipped(Decoupled(new MemControlWithStride(depth, strideDepth: Int)))
+    val test =
+      Flipped(Decoupled(new MemControlWithStride(depth, strideDepth: Int)))
+    val ok = Decoupled(Bool())
+  })
+
+  // when add, if it's a write increment its entry in the table
+  // when remove, if it's a write decrement its entryin the table (ie write completed)
+  // when test, if its entry in the table is 0 return true, otherwise false
+}

--- a/rtl/src/main/scala/tensil/mem/Port.scala
+++ b/rtl/src/main/scala/tensil/mem/Port.scala
@@ -17,3 +17,16 @@ class Port[T <: Data](gen: T, val depth: Long) extends Bundle {
   override def cloneType =
     (new Port(gen, depth)).asInstanceOf[this.type]
 }
+
+class PortWithStride[T <: Data](gen: T, val depth: Long, strideDepth: Int)
+    extends Bundle {
+  val control     = Flipped(Decoupled(new MemControlWithStride(depth, strideDepth)))
+  val input       = Flipped(Decoupled(gen))
+  val output      = Decoupled(gen)
+  val wrote       = Decoupled(Bool())
+  val status      = Decoupled(new MemControl(depth))
+  val inputStatus = Decoupled(gen)
+
+  override def cloneType =
+    (new PortWithStride(gen, depth, strideDepth)).asInstanceOf[this.type]
+}

--- a/rtl/src/main/scala/tensil/tcu/LocalRouter.scala
+++ b/rtl/src/main/scala/tensil/tcu/LocalRouter.scala
@@ -108,7 +108,8 @@ class LocalRouter[T <: Data](
       "accWriteDataMux",
       accWriteDataMuxModule.io.sel,
       arch.localDepth,
-      control.bits.size
+      control.bits.size,
+      bufferSize = arch.arraySize * 2,
     )
   memReadDataDemux.tieOff()
   memWriteDataMux.tieOff()

--- a/rtl/src/test/scala/tensil/Scratch.scala
+++ b/rtl/src/test/scala/tensil/Scratch.scala
@@ -11,7 +11,137 @@ import chiseltest._
 import tensil.util.decoupled.Counter
 import chisel3.util.Queue
 
-class Scratch extends Module { val io = IO(new Bundle {}) }
+class Scratch extends Module {
+  val gen               = UInt(8.W)
+  val depth             = 1 << 8
+  val blockSizeShift    = 4
+  val blockSize         = 1 << blockSizeShift
+  val maxRequestCount   = 1 << 8
+  val controlBufferSize = 8
+  val io = IO(new Bundle {
+
+    val a = new Bundle {
+      val in  = new Port(gen, depth)
+      val out = Flipped(new Port(gen, depth))
+    }
+    val b = new Bundle {
+      val in  = new Port(gen, depth)
+      val out = Flipped(new Port(gen, depth))
+    }
+  })
+
+  // new request on a comes in, what do we do?
+  val tableSize = depth / blockSize
+  val aTable    = Module(new CounterTable(tableSize, maxRequestCount))
+  val bTable    = Module(new CounterTable(tableSize, maxRequestCount))
+
+  val a = io.a
+  val b = io.b
+
+  val aControlQueue = Queue(a.in.control, controlBufferSize)
+  val bControlQueue = Queue(b.in.control, controlBufferSize)
+
+  aTable.io.incr.address := a.in.control.bits.address
+  aTable.io.incr.enable := a.in.control.bits.write
+  aTable.io.decr.address := aControlQueue.bits.address
+  aTable.io.decr.enable := aControlQueue.bits.write
+
+  bTable.io.incr.address := b.in.control.bits.address
+  bTable.io.incr.enable := b.in.control.bits.write
+  bTable.io.decr.address := bControlQueue.bits.address
+  bTable.io.decr.enable := bControlQueue.bits.write
+
+}
+
+class CounterTablePort(val size: Int) extends Bundle {
+  val address = UInt(log2Ceil(size).W)
+  val enable  = Bool()
+}
+
+class CounterTable(size: Int, maxCount: Int) extends Module {
+  val io = IO(new Bundle {
+    val incr = Input(new CounterTablePort(size))
+    val decr = Input(new CounterTablePort(size))
+    val read = Input(new CounterTablePort(size))
+    val data = Output(UInt(log2Ceil(size).W))
+  })
+
+  val table = RegInit(VecInit(Array.fill(size)(0.U(log2Ceil(maxCount).W))))
+
+  when(io.read.enable) {
+    io.data := table(io.read.address)
+  }.otherwise {
+    io.data := DontCare
+  }
+
+  when(io.incr.address === io.decr.address) {
+    val address = io.incr.address
+    when(io.incr.enable) {
+      when(io.decr.enable) {
+        // do nothing
+      }.otherwise {
+        incr()
+      }
+    }.otherwise {
+      when(io.decr.enable) {
+        decr()
+      }.otherwise {
+        // do nothing
+      }
+    }
+  }.otherwise {
+    when(io.incr.enable) {
+      incr()
+    }
+    when(io.decr.enable) {
+      decr()
+    }
+  }
+
+  def incr(): Unit = {
+    table(io.incr.address) := Mux(
+      table(io.incr.address) === (maxCount - 1).U,
+      table(io.incr.address),
+      table(io.incr.address) + 1.U
+    )
+  }
+
+  def decr(): Unit = {
+    table(io.decr.address) := Mux(
+      table(io.decr.address) === 0.U,
+      table(io.decr.address),
+      table(io.decr.address) - 1.U
+    )
+  }
+}
+
+class CounterTableSpec extends FunUnitSpec {
+  describe("CounterTable") {
+    describe("when size = 8, maxCount = 16") {
+      val size     = 8
+      val maxCount = 16
+      it("should increment and decrement") {
+        test(new CounterTable(size, maxCount)) { m =>
+          m.io.read.enable.poke(true.B)
+          m.io.incr.enable.poke(true.B)
+          for (i <- 0 until size) {
+            m.io.incr.address.poke(i.U)
+            m.io.read.address.poke(i.U)
+            m.clock.step()
+          }
+          m.io.incr.enable.poke(false.B)
+          m.io.decr.enable.poke(true.B)
+          for (i <- 0 until size) {
+            m.io.decr.address.poke(i.U)
+            m.io.read.address.poke(i.U)
+            m.clock.step()
+          }
+          m.io.decr.enable.poke(false.B)
+        }
+      }
+    }
+  }
+}
 
 class ScratchSpec extends UnitSpec {
   behavior of "Scratch"
@@ -19,4 +149,18 @@ class ScratchSpec extends UnitSpec {
   it should "work" in {
     test(new Scratch) { m => }
   }
+}
+
+class Port[T <: Data](gen: T, depth: Long) extends Bundle {
+  val control = Flipped(Decoupled(new Request(depth)))
+  val input   = Flipped(Decoupled(gen))
+  val output  = Decoupled(gen)
+
+  override def cloneType =
+    (new Port(gen, depth)).asInstanceOf[this.type]
+}
+
+class Request(val depth: Long) extends Bundle {
+  val address = UInt(log2Ceil(depth).W)
+  val write   = Bool()
 }

--- a/rtl/src/test/scala/tensil/Scratch.scala
+++ b/rtl/src/test/scala/tensil/Scratch.scala
@@ -10,6 +10,7 @@ import chisel3.util.Decoupled
 import chiseltest._
 import tensil.util.decoupled.Counter
 import chisel3.util.Queue
+import chisel3.util.DecoupledIO
 
 class Scratch extends Module {
   val gen               = UInt(8.W)
@@ -21,12 +22,12 @@ class Scratch extends Module {
   val io = IO(new Bundle {
 
     val a = new Bundle {
-      val in  = new Port(gen, depth)
-      val out = Flipped(new Port(gen, depth))
+      val in  = Flipped(Decoupled(new Request(depth)))
+      val out = Decoupled(new Request(depth))
     }
     val b = new Bundle {
-      val in  = new Port(gen, depth)
-      val out = Flipped(new Port(gen, depth))
+      val in  = Flipped(Decoupled(new Request(depth)))
+      val out = Decoupled(new Request(depth))
     }
   })
 
@@ -38,19 +39,57 @@ class Scratch extends Module {
   val a = io.a
   val b = io.b
 
-  val aControlQueue = Queue(a.in.control, controlBufferSize)
-  val bControlQueue = Queue(b.in.control, controlBufferSize)
+  val aQueue = Queue(a.in, controlBufferSize)
+  val bQueue = Queue(b.in, controlBufferSize)
 
-  aTable.io.incr.address := a.in.control.bits.address
-  aTable.io.incr.enable := a.in.control.bits.write
-  aTable.io.decr.address := aControlQueue.bits.address
-  aTable.io.decr.enable := aControlQueue.bits.write
+  val bSafe = connectTable(aTable, a.in, aQueue, bQueue)
+  val aSafe = connectTable(bTable, b.in, bQueue, aQueue)
 
-  bTable.io.incr.address := b.in.control.bits.address
-  bTable.io.incr.enable := b.in.control.bits.write
-  bTable.io.decr.address := bControlQueue.bits.address
-  bTable.io.decr.enable := bControlQueue.bits.write
+  when(aSafe) {
+    when(bSafe) {
+      // both can proceed
+      a.out <> aQueue
+      b.out <> bQueue
+    }.otherwise {
+      // a can proceed, b cannot
+      a.out <> aQueue
+      bQueue.ready := false.B
+      b.out.valid := false.B
+      b.out.bits <> bQueue.bits
+    }
+  }.otherwise {
+    when(bSafe) {
+      // b can proceed, a cannot
+      aQueue.ready := false.B
+      a.out.valid := false.B
+      a.out.bits <> aQueue.bits
+      b.out <> bQueue
+    }.otherwise {
+      // both unsafe to proceed, a gets priority to ensure progress is made
+      a.out <> aQueue
+      bQueue.ready := false.B
+      b.out.valid := false.B
+      b.out.bits <> bQueue.bits
+    }
+  }
 
+  def connectTable(
+      table: CounterTable,
+      in: DecoupledIO[Request],
+      queue: DecoupledIO[Request],
+      altQueue: DecoupledIO[Request],
+  ): Bool = {
+    table.io.incr.address := in.bits.address
+    table.io.incr.enable := in.fire() && in.bits.write
+    table.io.decr.address := queue.bits.address
+    table.io.decr.enable := queue.fire() && queue.bits.write
+
+    table.io.read.address := altQueue.bits.address
+    table.io.read.enable := altQueue.valid
+    // safe for the alternate control queue to proceed
+    val altSafe = !(table.io.read.enable && table.io.count =/= 0.U)
+    altSafe
+  }
 }
 
 class CounterTablePort(val size: Int) extends Bundle {
@@ -60,18 +99,18 @@ class CounterTablePort(val size: Int) extends Bundle {
 
 class CounterTable(size: Int, maxCount: Int) extends Module {
   val io = IO(new Bundle {
-    val incr = Input(new CounterTablePort(size))
-    val decr = Input(new CounterTablePort(size))
-    val read = Input(new CounterTablePort(size))
-    val data = Output(UInt(log2Ceil(size).W))
+    val incr  = Input(new CounterTablePort(size))
+    val decr  = Input(new CounterTablePort(size))
+    val read  = Input(new CounterTablePort(size))
+    val count = Output(UInt(log2Ceil(size).W))
   })
 
   val table = RegInit(VecInit(Array.fill(size)(0.U(log2Ceil(maxCount).W))))
 
   when(io.read.enable) {
-    io.data := table(io.read.address)
+    io.count := table(io.read.address)
   }.otherwise {
-    io.data := DontCare
+    io.count := DontCare
   }
 
   when(io.incr.address === io.decr.address) {
@@ -98,7 +137,7 @@ class CounterTable(size: Int, maxCount: Int) extends Module {
     }
   }
 
-  def incr(): Unit = {
+  private def incr(): Unit = {
     table(io.incr.address) := Mux(
       table(io.incr.address) === (maxCount - 1).U,
       table(io.incr.address),
@@ -106,7 +145,7 @@ class CounterTable(size: Int, maxCount: Int) extends Module {
     )
   }
 
-  def decr(): Unit = {
+  private def decr(): Unit = {
     table(io.decr.address) := Mux(
       table(io.decr.address) === 0.U,
       table(io.decr.address),
@@ -147,7 +186,15 @@ class ScratchSpec extends UnitSpec {
   behavior of "Scratch"
 
   it should "work" in {
-    test(new Scratch) { m => }
+    test(new Scratch) { m =>
+      m.io.a.in.setSourceClock(m.clock)
+      m.io.a.out.setSinkClock(m.clock)
+      m.io.b.in.setSourceClock(m.clock)
+      m.io.b.out.setSinkClock(m.clock)
+
+      m.io.a.in.enqueue(Request(m.depth, 0, true))
+      m.io.b.in.enqueue(Request(m.depth, 0, false))
+    }
   }
 }
 
@@ -163,4 +210,10 @@ class Port[T <: Data](gen: T, depth: Long) extends Bundle {
 class Request(val depth: Long) extends Bundle {
   val address = UInt(log2Ceil(depth).W)
   val write   = Bool()
+}
+
+object Request {
+  def apply(depth: Long, address: Int, write: Boolean): Request = {
+    (new Request(depth)).Lit(_.address -> address.U, _.write -> write.B)
+  }
 }

--- a/sim/test/src/tcu/TCUSpec.scala
+++ b/sim/test/src/tcu/TCUSpec.scala
@@ -10,6 +10,7 @@ import tensil.{Architecture, UnitSpec}
 import tensil.data.{CartesianProduct, Index, Shape, Slice, Tensor, TensorReader}
 import tensil.tcu.instruction._
 import tensil.util.divCeil
+import tensil.util.zero
 import tensil.decoupled.{decoupledToDriver, decoupledVecToDriver}
 import tensil.mem.MemControl
 import tensil.tools.Xor
@@ -25,6 +26,64 @@ import tensil.mem.MemKind
 
 class TCUSpec extends UnitSpec {
   behavior of "TCU"
+
+  it should "process matmuls and accumulates simultaneously" in {
+    val gen = FixedPoint(16.W, 8.BP)
+    val arch = Architecture.mkWithDefaults(
+      arraySize = 8,
+      accumulatorDepth = 64,
+      localDepth = 64,
+      stride0Depth = 8,
+      stride1Depth = 8,
+    )
+    val layout = InstructionLayout(arch)
+    decoupledTest(new TCU(gen, layout)) { m =>
+      implicit val layout = m.setInstructionParameters()
+      m.setClocks()
+
+      val n    = 10
+      val size = 10
+
+      thread("instruction") {
+        for (_ <- 0 until n) {
+          m.io.instruction.enqueue(
+            Instruction(
+              Opcode.MatMul,
+              MatMulFlags(false, false),
+              MatMulArgs(0, 0, size - 1),
+            )
+          )
+        }
+        m.io.instruction.enqueue(
+          Instruction(
+            Opcode.DataMove,
+            DataMoveFlags(DataMoveKind.memoryToDram0),
+            DataMoveArgs(0, 0, 0),
+          )
+        )
+      }
+
+      thread("dram0.control") {
+        var count = 0
+        while (!m.io.dram0.control.valid.peek().litToBoolean) {
+          m.clock.step()
+          count += 1
+        }
+        m.io.dram0.control.expectDequeue(
+          MemControl(arch.dram0Depth, 0.U, 0.U, true.B)
+        )
+        println(count)
+        assert(count < 110)
+      }
+
+      thread("dram0.data") {
+        m.io.dram0.dataOut
+          .expectDequeue(
+            Array.fill(arch.arraySize)(0.F(gen.getWidth.W, gen.binaryPoint))
+          )
+      }
+    }
+  }
 
   it should "handle matmul, datamove (local => acc) then SIMD" in {
     val gen = FixedPoint(16.W, 8.BP)


### PR DESCRIPTION
This change fixes a bug where matmuls and accs would wait on each other instead of proceeding in parallel. The problem was that the control queues feeding them were implicitly linked, meaning that one could not get too far ahead of the other. We add buffers in these places to cut dependencies between buses fed by the same control inputs. In this case the buffer size was sometimes set to 2x the array size to account for the fact that accumulate operations can't begin until data has propagated through the array.