### PR TITLE
Optimize ONNX node traversal

### DIFF
--- a/tools/src/tensil/tools/compiler/OnnxFrontend.scala
+++ b/tools/src/tensil/tools/compiler/OnnxFrontend.scala
@@ -193,15 +193,16 @@ class OnnxFrontend(
       .map(outputNodeNames(_))
       .flatten
       .distinct
-      .foldLeft(prev)((prev, nodeName) => {
-        recursiveTraverse(
-          nodeName +: prev,
-          nodeProtos(nodeName).input.toSet
-            .diff(tensorProtos.keySet ++ inputValueInfoProtos.keySet)
-            .toSeq
-        )
-      })
-      .distinct
+      .foldLeft(prev)((prev, nodeName) =>
+        if (!prev.contains(nodeName))
+          recursiveTraverse(
+            prev,
+            nodeProtos(nodeName).input.toSet
+              .diff(tensorProtos.keySet ++ inputValueInfoProtos.keySet)
+              .toSeq
+          ) :+ nodeName
+        else prev
+      )
   }
 
   /*


### PR DESCRIPTION
Previous algorithm did traversal for all possible paths in the model graph and later applied `distinct` to prune the redundancy. With this change the algorithm terminates the path once previously traversed node is reached.