### PR TITLE
Fix typo in error message

### DIFF
--- a/rtl/src/main/scala/tensil/zynq/tcu/Top.scala
+++ b/rtl/src/main/scala/tensil/zynq/tcu/Top.scala
@@ -136,7 +136,7 @@ object Top extends App {
       .valueName("32|64|128|256")
       .validate(x =>
         if (Seq(32, 64, 128, 256).contains(x)) success
-        else failure("Value must be 64, 128 or 256")
+        else failure("Value must be 32, 64, 128 or 256")
       )
       .action((x, c) =>
         c.copy(dramAxiConfig = x match {


### PR DESCRIPTION
An AXI bus width of 32 is accepted, but the error message does not say it is legal.