### PR TITLE
Perform fixed point saturation in accumulators

### DIFF
--- a/rtl/src/main/scala/tensil/util/decoupled/VecAdder.scala
+++ b/rtl/src/main/scala/tensil/util/decoupled/VecAdder.scala
@@ -5,7 +5,7 @@ package tensil.util.decoupled
 
 import chisel3._
 import chisel3.util.{Decoupled, Queue}
-import tensil.util
+import tensil.util.plus
 
 class VecAdder[T <: Data with Num[T]](gen: T, size: Int) extends Module {
   val io = IO(new Bundle {
@@ -18,7 +18,7 @@ class VecAdder[T <: Data with Num[T]](gen: T, size: Int) extends Module {
   val right = io.right
 
   for (i <- 0 until size) {
-    io.output.bits(i) := left.bits(i) + right.bits(i)
+    io.output.bits(i) := plus(gen, left.bits(i), right.bits(i))
   }
   io.output.valid := left.valid && right.valid
   left.ready := io.output.ready && right.valid


### PR DESCRIPTION
When running massive dense layers of speech commands model we've observed incorrect results. Analysis led to wrapping on overflow during `MatMul` with accumulation.