### PR TITLE
Fix web compiler

### DIFF
--- a/README.md
+++ b/README.md
@@ -141,6 +141,15 @@ To view a specific VCD file:
 ./scripts/gtkwave/display-vcd.sh <vcd_file>
 ```
 
+### Build and push AWS ECS image for web compiler (Tensil Explorer)
+
+```
+docker build -f docker/web/Dockerfile -t tensil-web-compiler .
+aws ecr get-login-password | docker login --username AWS --password-stdin <ACCOUNT ID>.dkr.ecr.<REGION>.amazonaws.com
+docker tag tensil-web-compiler <ACCOUNT ID>.dkr.ecr.<REGION>.amazonaws.com/tf2rtl-web-compiler
+docker push <ACCOUNT ID>.dkr.ecr.<REGION>.amazonaws.com/tf2rtl-web-compiler
+```
+
 ## Get help
 
 - Say hello and ask a question on our [Discord](https://discord.gg/TSw34H3PXr)

--- a/docker/web/Dockerfile
+++ b/docker/web/Dockerfile
@@ -1,0 +1,19 @@
+FROM azul/zulu-openjdk:11 as build
+
+RUN apt-get update && apt-get -y install curl
+
+WORKDIR /work
+COPY mill build.sc ./
+ADD common ./common
+ADD tools ./tools
+ADD web ./web
+
+RUN ls -la
+RUN ./mill 'web.assembly'
+
+FROM azul/zulu-openjdk:11
+
+RUN mkdir -p /opt/tensil
+COPY --from=build /work/out/web/assembly.dest/out.jar /opt/tensil/web.jar
+
+CMD java -jar /opt/tensil/web.jar

--- a/tools/src/tensil/tools/compiler/MemoryManager.scala
+++ b/tools/src/tensil/tools/compiler/MemoryManager.scala
@@ -252,10 +252,11 @@ class MemoryManager(
   private var constsUtilizations = mutable.ArrayBuffer.empty[Float]
   private var constsScalarSizes  = mutable.ArrayBuffer.empty[Long]
 
-  private def addConstSize(scalarSize: Long, vectorSize: Long): Unit = {
-    constsUtilizations += scalarSize.toFloat / (vectorSize * arch.arraySize).toFloat
-    constsScalarSizes += scalarSize
-  }
+  private def addConstSize(scalarSize: Long, vectorSize: Long): Unit =
+    if (scalarSize != 0 && vectorSize != 0) {
+      constsUtilizations += scalarSize.toFloat / (vectorSize * arch.arraySize).toFloat
+      constsScalarSizes += scalarSize
+    }
 
   private def mkConstObject(
       name: String,

--- a/web/src/tensil/tools/web/Main.scala
+++ b/web/src/tensil/tools/web/Main.scala
@@ -32,11 +32,11 @@ object CompilerTask {
   implicit val rw: ReadWriter[CompilerTask] = macroRW
 
   // TODO: these queue, table and bucket names to be configured from container environment
-  val queue          = sqs.queue("tensil-web-compiler-7af9ea2").get
-  val jobTable       = db.table("tensil-web-job-c9cb5e4").get
-  val taskTable      = db.table("tensil-web-task-731b0cb").get
-  val compilerBucket = s3.bucket("tensil-web-compiler-8681a04").get
-  val uploadsBucket  = s3.bucket("tensil-web-upload-7a8bd18").get
+  val queue          = sqs.queue("tf2rtl-web-compiler-7af9ea2").get
+  val jobTable       = db.table("tf2rtl-web-job-c9cb5e4").get
+  val taskTable      = db.table("tf2rtl-web-task-731b0cb").get
+  val compilerBucket = s3.bucket("tf2rtl-web-compiler-8681a04").get
+  val uploadsBucket  = s3.bucket("tf2rtl-web-upload-7a8bd18").get
 
   def process(count: Int = 1) = {
     val messages = sqs.receiveMessage(queue, count, 5)


### PR DESCRIPTION
- Re-introduce Dockerfile for web compiler based on mill build;
- Fix consts utilization calculation in memory manager;
- Fix AWS object names changed during global renaming
- Document building web compiler image.