### PR TITLE
Report accurate local and accumulator usage

### DIFF
--- a/tools/src/tensil/tools/Compiler.scala
+++ b/tools/src/tensil/tools/Compiler.scala
@@ -534,14 +534,12 @@ object Compiler {
 
       val dram0SpaceUsage = dram0Space.usage
       val dram1SpaceUsage = dram1Space.usage
-      val accumulatorUsage =
-        if (!layerSchedulerResults.isEmpty)
-          new MemoryUsage(
-            maxSize = layerSchedulerResults.map(_.accumulatorUsage.maxSize).max,
-            aggSize = layerSchedulerResults.map(_.accumulatorUsage.aggSize).sum
-          )
-        else MemoryUsage(0, 0)
-      val localUsage = localSpace.usage
+      val accumulatorUsage = MemoryUsage(
+        layerSchedulerResults.map(_.accumulatorUsage)
+      )
+      val localUsage = MemoryUsage(
+        localSpace.usage +: layerSchedulerResults.map(_.localUsage)
+      )
 
       if (dram0SpaceUsage.maxSize != 0)
         tb.addNamedLine(

--- a/tools/src/tensil/tools/Compiler.scala
+++ b/tools/src/tensil/tools/Compiler.scala
@@ -590,6 +590,16 @@ object Compiler {
           accumulatorUsage.aggSize * options.arch.arraySize
         )
       tb.addNamedLine("Number of layers", layerSchedulerResults.size)
+      if (!layerSchedulerResults.isEmpty) {
+        tb.addNamedLine(
+          "Maximum number of combined stages",
+          layerSchedulerResults.map(_.numberOfCombinedStages).max
+        )
+        tb.addNamedLine(
+          "Maximum number of partitions",
+          layerSchedulerResults.map(_.numberOfPartitions).max
+        )
+      }
       Stats.printSummary(
         backendStats,
         tb,
@@ -719,7 +729,7 @@ object Compiler {
               "Accumulator utilization (%):"
             ) ++ groupResultsWithIndex
               .map(
-                _._1.accumulatorUsage.maxSize / options.arch.accumulatorDepth
+                _._1.accumulatorUsage.maxSize.toFloat / options.arch.accumulatorDepth.toFloat
               )
               .map(_ * 100f)
               .map(f => f"$f%.1f")
@@ -728,7 +738,9 @@ object Compiler {
         tb.addLine(
           new TableLine(
             List("Local utilization (%):") ++ groupResultsWithIndex
-              .map(_._1.localUsage.maxSize / options.arch.threadLocalDepth)
+              .map(
+                _._1.localUsage.maxSize.toFloat / options.arch.threadLocalDepth.toFloat
+              )
               .map(_ * 100f)
               .map(f => f"$f%.1f")
           )

--- a/tools/src/tensil/tools/Compiler.scala
+++ b/tools/src/tensil/tools/Compiler.scala
@@ -592,8 +592,8 @@ object Compiler {
       tb.addNamedLine("Number of layers", layerSchedulerResults.size)
       if (!layerSchedulerResults.isEmpty) {
         tb.addNamedLine(
-          "Maximum number of combined stages",
-          layerSchedulerResults.map(_.numberOfCombinedStages).max
+          "Maximum number of stages",
+          layerSchedulerResults.map(_.numberOfStages).max
         )
         tb.addNamedLine(
           "Maximum number of partitions",
@@ -648,14 +648,6 @@ object Compiler {
               "Number of stages:"
             ) ++ groupResultsWithIndex
               .map(_._1.numberOfStages)
-          )
-        )
-        tb.addLine(
-          new TableLine(
-            List(
-              "Number of combined stages:"
-            ) ++ groupResultsWithIndex
-              .map(_._1.numberOfCombinedStages)
           )
         )
         tb.addLine(

--- a/tools/src/tensil/tools/compiler/ArenaMemorySpace.scala
+++ b/tools/src/tensil/tools/compiler/ArenaMemorySpace.scala
@@ -49,4 +49,7 @@ class ArenaMemorySpace private (
 
   override def clone(): MemorySpace =
     new ArenaMemorySpace(name, tag, depth, next)
+
+  override def maxSize: MemoryAddressRaw = next
+  override def aggSize: MemoryAddressRaw = next
 }

--- a/tools/src/tensil/tools/compiler/ArenaMemorySpace.scala
+++ b/tools/src/tensil/tools/compiler/ArenaMemorySpace.scala
@@ -23,8 +23,9 @@ class ArenaMemorySpace private (
     val name: String,
     val tag: MemoryTag,
     val depth: MemoryAddressRaw,
-    private var next: MemoryAddressRaw
+    private val base: MemoryAddressRaw
 ) extends MemorySpace {
+  private var next = base
   def allocate(
       ref: MemoryRef,
       size: MemoryAddressRaw
@@ -47,9 +48,8 @@ class ArenaMemorySpace private (
       "Freeing from arena memory space is not supported"
     )
 
-  override def clone(): MemorySpace =
+  override def fork(): MemorySpace =
     new ArenaMemorySpace(name, tag, depth, next)
 
-  override def maxSize: MemoryAddressRaw = next
-  override def aggSize: MemoryAddressRaw = next
+  override def usage = MemoryUsage(maxSize = next, aggSize = next - base)
 }

--- a/tools/src/tensil/tools/compiler/HeapMemorySpace.scala
+++ b/tools/src/tensil/tools/compiler/HeapMemorySpace.scala
@@ -63,6 +63,6 @@ class HeapMemorySpace private (
     )
   }
 
-  def maxSize: MemoryAddressRaw = maxSizeVar
-  def aggSize: MemoryAddressRaw = aggSizeVar
+  override def maxSize: MemoryAddressRaw = maxSizeVar
+  override def aggSize: MemoryAddressRaw = aggSizeVar
 }

--- a/tools/src/tensil/tools/compiler/HeapMemorySpace.scala
+++ b/tools/src/tensil/tools/compiler/HeapMemorySpace.scala
@@ -3,6 +3,8 @@
 
 package tensil.tools.compiler
 
+import tensil.tools.CompilerException
+
 object HeapMemorySpace {
   def apply(
       name: String,
@@ -12,10 +14,7 @@ object HeapMemorySpace {
     new HeapMemorySpace(
       name,
       tag,
-      depth,
-      MemoryAddressRaw.Zero,
-      MemoryAddressRaw.Zero,
-      (MemoryAddressRaw.Zero until depth).toArray
+      depth
     )
 }
 
@@ -23,10 +22,10 @@ class HeapMemorySpace private (
     val name: String,
     val tag: MemoryTag,
     val depth: MemoryAddressRaw,
-    private var aggSizeVar: MemoryAddressRaw,
-    private var maxSizeVar: MemoryAddressRaw,
-    private var rawFreeSpan: Array[MemoryAddressRaw]
 ) extends MemorySpace {
+  private var aggSizeVar  = MemoryAddressRaw.Zero
+  private var maxSizeVar  = MemoryAddressRaw.Zero
+  private var rawFreeSpan = (MemoryAddressRaw.Zero until depth).toArray
 
   override def allocate(
       ref: MemoryRef,
@@ -52,17 +51,8 @@ class HeapMemorySpace private (
       (span.filter(a => a.tag == tag).map(_.raw) ++ rawFreeSpan).sorted.toArray
   }
 
-  override def clone(): MemorySpace = {
-    new HeapMemorySpace(
-      name,
-      tag,
-      depth,
-      aggSizeVar,
-      maxSizeVar,
-      rawFreeSpan.clone()
-    )
-  }
+  override def fork(): MemorySpace =
+    throw new CompilerException("Forking heap memory space is not supported")
 
-  override def maxSize: MemoryAddressRaw = maxSizeVar
-  override def aggSize: MemoryAddressRaw = aggSizeVar
+  override def usage = MemoryUsage(maxSize = maxSizeVar, aggSize = aggSizeVar)
 }

--- a/tools/src/tensil/tools/compiler/IsolatedLocalScheduler.scala
+++ b/tools/src/tensil/tools/compiler/IsolatedLocalScheduler.scala
@@ -254,15 +254,14 @@ class IsolatedLocalScheduler(
       }
     }
 
-    val name                   = s"LAYER $layerIndex"
-    val numberOfStages         = rootsByStages.size
-    val stages                 = combineStages()
-    val numberOfCombinedStages = stages.size
-    val partitions             = stages.map(_.partitions).flatten
-    val numberOfPartitions     = partitions.size
-    val maximumRootsSize       = partitions.map(_.roots.get.size).max
-    val accumulatorSize        = partitions.map(_.estimatedUsage.accumulatorSize).max
-    val localSize              = partitions.map(_.estimatedUsage.localSize).max
+    val name               = s"LAYER $layerIndex"
+    val stages             = combineStages()
+    val numberOfStages     = stages.size
+    val partitions         = stages.map(_.partitions).flatten
+    val numberOfPartitions = partitions.size
+    val maximumRootsSize   = partitions.map(_.roots.get.size).max
+    val accumulatorSize    = partitions.map(_.estimatedUsage.accumulatorSize).max
+    val localSize          = partitions.map(_.estimatedUsage.localSize).max
 
     val accumulatorUtilization =
       accumulatorSize.toFloat / context.options.arch.accumulatorDepth.toFloat
@@ -273,7 +272,7 @@ class IsolatedLocalScheduler(
 
     if (context.options.printProgress) {
       println(
-        s"HIR scheduled onto ${numberOfCombinedStages} stage(s) and ${numberOfPartitions} partition(s)"
+        s"HIR scheduled onto ${numberOfStages} stage(s) and ${numberOfPartitions} partition(s)"
       )
     }
 
@@ -450,7 +449,6 @@ class IsolatedLocalScheduler(
     if (context.options.printSchedulerSummary) {
       val tb = new TablePrinter(Some(s"$name SCHEDULER SUMMARY"))
       tb.addNamedLine("Stages", numberOfStages)
-      tb.addNamedLine("Combined Stages", numberOfCombinedStages)
       tb.addNamedLine("Partitions", numberOfPartitions)
       tb.addNamedLine("Partition results size", maximumRootsSize)
       tb.addNamedLine("Partition accumulator size", accumulatorSize)
@@ -526,7 +524,6 @@ class IsolatedLocalScheduler(
 
     SchedulerResult(
       numberOfStages = numberOfStages,
-      numberOfCombinedStages = numberOfCombinedStages,
       numberOfPartitions = numberOfPartitions,
       cycles = stats.aggregateCycles,
       energy = stats.aggregateEnergy,

--- a/tools/src/tensil/tools/compiler/IsolatedLocalScheduler.scala
+++ b/tools/src/tensil/tools/compiler/IsolatedLocalScheduler.scala
@@ -310,7 +310,9 @@ class IsolatedLocalScheduler(
           val partitionSegmentAndStats = stage.partitions.zipWithIndex.par
             .map({
               case (partition, j) =>
-                val partitionLocalAllocator = initLocalAllocator.clone()
+                val partitionLocalSpace = localSpace.fork()
+                val partitionLocalAllocator =
+                  initLocalAllocator.fork(partitionLocalSpace)
                 val kinds = Seq(
                   BackendSegmentKey.Load,
                   BackendSegmentKey.Compute,
@@ -342,7 +344,7 @@ class IsolatedLocalScheduler(
                   nodes
                 )
 
-                lowerCompute(
+                val accumulatorUsage = lowerCompute(
                   segmentsByKind(BackendSegmentKey.Compute).segmentLir,
                   partitionLocalAllocator,
                   nodes
@@ -479,8 +481,8 @@ class IsolatedLocalScheduler(
       numberOfPartitions = numberOfPartitions,
       cycles = stats.aggregateCycles,
       energy = stats.aggregateEnergy,
-      accumulatorUtilization = accumulatorUtilization,
-      localUtilization = localUtilization,
+      //accumulatorUtilization = accumulatorUtilization,
+      //localUtilization = localUtilization,
       macs = macs,
       macEfficiency = macEfficiency,
     )

--- a/tools/src/tensil/tools/compiler/MemorySpace.scala
+++ b/tools/src/tensil/tools/compiler/MemorySpace.scala
@@ -14,4 +14,7 @@ trait MemorySpace extends mutable.Cloneable[MemorySpace] {
   ): Option[MemorySpan]
 
   def free(span: MemorySpan): Unit
+
+  def maxSize: MemoryAddressRaw
+  def aggSize: MemoryAddressRaw
 }

--- a/tools/src/tensil/tools/compiler/MemorySpace.scala
+++ b/tools/src/tensil/tools/compiler/MemorySpace.scala
@@ -3,13 +3,6 @@
 
 package tensil.tools.compiler
 
-import scala.collection.mutable
-
-case class MemoryUsage(
-    maxSize: MemoryAddressRaw,
-    aggSize: MemoryAddressRaw
-)
-
 trait MemorySpace {
   val name: String
 

--- a/tools/src/tensil/tools/compiler/MemorySpace.scala
+++ b/tools/src/tensil/tools/compiler/MemorySpace.scala
@@ -5,7 +5,12 @@ package tensil.tools.compiler
 
 import scala.collection.mutable
 
-trait MemorySpace extends mutable.Cloneable[MemorySpace] {
+case class MemoryUsage(
+    maxSize: MemoryAddressRaw,
+    aggSize: MemoryAddressRaw
+)
+
+trait MemorySpace {
   val name: String
 
   def allocate(
@@ -15,6 +20,7 @@ trait MemorySpace extends mutable.Cloneable[MemorySpace] {
 
   def free(span: MemorySpan): Unit
 
-  def maxSize: MemoryAddressRaw
-  def aggSize: MemoryAddressRaw
+  def fork(): MemorySpace
+
+  def usage: MemoryUsage
 }

--- a/tools/src/tensil/tools/compiler/MemoryUsage.scala
+++ b/tools/src/tensil/tools/compiler/MemoryUsage.scala
@@ -1,0 +1,19 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright © 2019-2022 Tensil AI Company */
+
+package tensil.tools.compiler
+
+object MemoryUsage {
+  def apply(usages: Seq[MemoryUsage]): MemoryUsage =
+    if (!usages.isEmpty)
+      new MemoryUsage(
+        maxSize = usages.map(_.maxSize).max,
+        aggSize = usages.map(_.aggSize).sum
+      )
+    else MemoryUsage(0, 0)
+}
+
+case class MemoryUsage(
+    maxSize: MemoryAddressRaw,
+    aggSize: MemoryAddressRaw
+)

--- a/tools/src/tensil/tools/compiler/RenamingMemoryAllocator.scala
+++ b/tools/src/tensil/tools/compiler/RenamingMemoryAllocator.scala
@@ -19,7 +19,7 @@ class RenamingMemoryAllocator private (
     space: MemorySpace,
     refTags: Set[MemoryTag],
     private val renameMap: mutable.Map[MemoryAddress, MemoryAddress]
-) extends mutable.Cloneable[RenamingMemoryAllocator] {
+) {
   def locate(refAddress: MemoryAddress): MemoryAddress =
     if (refTags.contains(refAddress.tag)) renameMap(refAddress) else refAddress
 
@@ -57,6 +57,6 @@ class RenamingMemoryAllocator private (
     renameMap.clear()
   }
 
-  override def clone(): RenamingMemoryAllocator =
-    new RenamingMemoryAllocator(space.clone(), refTags, renameMap.clone())
+  def fork(space: MemorySpace): RenamingMemoryAllocator =
+    new RenamingMemoryAllocator(space, refTags, renameMap.clone())
 }

--- a/tools/src/tensil/tools/compiler/Scheduler.scala
+++ b/tools/src/tensil/tools/compiler/Scheduler.scala
@@ -31,8 +31,8 @@ case class SchedulerResult(
     numberOfPartitions: Int = 0,
     cycles: Long = 0,
     energy: Long = 0,
-    accumulatorUtilization: Float = 0,
-    localUtilization: Float = 0,
+    accumulatorUsage: MemoryUsage = MemoryUsage(0, 0),
+    localUsage: MemoryUsage = MemoryUsage(0, 0),
     macs: Long = 0,
     macEfficiency: Float = Float.NaN
 ) {}
@@ -620,7 +620,7 @@ abstract class Scheduler(
       lir: LIR,
       localAllocator: RenamingMemoryAllocator,
       nodes: Seq[Node]
-  ): Unit = {
+  ): MemoryUsage = {
     val accumulatorSpace = ArenaMemorySpace(
       "Accumulator",
       MemoryTag.Accumulators,
@@ -1174,6 +1174,8 @@ abstract class Scheduler(
     }
 
     saveAccRollup.finalEmit()
+
+    accumulatorSpace.usage
   }
 
   protected def lowerSaveVars(

--- a/tools/src/tensil/tools/compiler/Scheduler.scala
+++ b/tools/src/tensil/tools/compiler/Scheduler.scala
@@ -26,7 +26,6 @@ import tensil.tools.util
 import tensil.{TablePrinter, TableLine, Architecture}
 
 case class SchedulerResult(
-    numberOfCombinedStages: Int = 0,
     numberOfStages: Int = 0,
     numberOfPartitions: Int = 0,
     cycles: Long = 0,

--- a/tools/src/tensil/tools/compiler/SharedLocalScheduler.scala
+++ b/tools/src/tensil/tools/compiler/SharedLocalScheduler.scala
@@ -63,7 +63,7 @@ class SharedLocalScheduler(
       nodes
     )
 
-    lowerCompute(
+    val accumulatorUsage = lowerCompute(
       segmentsByKind(BackendSegmentKey.Compute).segmentLir,
       localAllocator,
       nodes
@@ -155,8 +155,7 @@ class SharedLocalScheduler(
       numberOfPartitions = 1,
       cycles = stats.aggregateCycles,
       energy = stats.aggregateEnergy,
-      accumulatorUtilization = accumulatorUtilization,
-      localUtilization = localUtilization,
+      accumulatorUsage = accumulatorUsage,
       macs = macs,
       macEfficiency = macEfficiency,
     )

--- a/tools/src/tensil/tools/compiler/SharedLocalScheduler.scala
+++ b/tools/src/tensil/tools/compiler/SharedLocalScheduler.scala
@@ -151,7 +151,6 @@ class SharedLocalScheduler(
 
     SchedulerResult(
       numberOfStages = 1,
-      numberOfCombinedStages = 1,
       numberOfPartitions = 1,
       cycles = stats.aggregateCycles,
       energy = stats.aggregateEnergy,


### PR DESCRIPTION
This PR introduces accurate reporting for local memory and accumulators usage. Previously upper-boundary estimate was reported. The compiler summary reports usage maximum and aggregate sizes across all of the layers. Aggregate is the total size of all objects allocated and maximum is a high-water mark. Layers summary reports utilization percentage per layer, which is based on the ratio between the maximum memory usage and its architectural depth.

In addition, the compiler summary now includes the maximum number of stages and partitions across all of the layers. When both are equal to one the user may consider using strategies other than the default (`local-isolated`).

Following are usage values for various memories and compiler strategies for ResNet20/CIFAR on ZCU104.

### Maximum

  | DRAM0 | DRAM1 | Local | Accumulators
-- | -- | -- | -- | --
local-vars-and-consts | 1,024 | 0 | 25,971 | 8,196
local-vars | 1,024 | 18,803 | 7,238 | 8,196
local-consts | 7,168 | 0 | 25,971 | 8,196
local-isolated | 7,168 | 18,803 | 7,238* | 8,196*

(*) These maximums are for one stage with one partition case. The `local-isolated` strategy can split stages and partition for smaller memories.

### Aggregate

  | DRAM0 | DRAM1 | Local | Accumulators
-- | -- | -- | -- | --
local-vars-and-consts | 1,024 | 0 | 47,996 | 54,851
local-vars | 1,024 | 18,803 | 48,010 | 54,851
local-consts | 29,193 | 0 | 75,652 | 54,851
local-isolated | 29,193 | 18,803 | 75,666 | 54,851

